### PR TITLE
Add application-form deep-link discovery to job skills

### DIFF
--- a/.agents/skills/find-kristian-jobs/SKILL.md
+++ b/.agents/skills/find-kristian-jobs/SKILL.md
@@ -57,7 +57,7 @@ When parsing a posting with Jina Reader, always look for: `Posted`, `Date posted
 | Search LinkedIn Jobs (authenticated) | `mcp__claude-in-chrome__*` browser tools |
 | Parse job posting content | `Bash`: `bash .agents/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
 | Fetch application form + questions | `Bash`: `bash .agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` |
-| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `get_page_text` on the `apply_url` |
+| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` on the `apply_url` |
 | Fallback fetch | `WebFetch` |
 
 **URL Caching with qurl — check before every fetch:**
@@ -136,14 +136,14 @@ leads/
 
 Budget: max 4 career page fetches + LinkedIn browser search.
 
-1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `get_page_text` to extract roles:
+1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://openai.com/careers/search/`
    - `https://www.anthropic.com/careers/jobs`
    - `https://holtzbrinck.com/en/jobs`
    - On each career page, check for a "posted date" or "last updated" field; skip any role posted more than 5 months ago or marked closed.
 2. Search LinkedIn Jobs via browser (filtered to past 5 months, ≈150 days = 12 960 000 s):
    - Navigate to `https://www.linkedin.com/jobs/search/?keywords=AI+Engineer+research+infrastructure&location=Europe&f_TPR=r12960000`
-   - Use `get_page_text` to extract job titles, companies, URLs, **and posted dates**
+   - Use `mcp__claude-in-chrome__get_page_text` to extract job titles, companies, URLs, **and posted dates**
    - Run 1–2 additional LinkedIn searches varying keywords (Staff Engineer LLM, Head of AI open science) using the same `f_TPR=r12960000` filter
    - Discard any result where LinkedIn shows "Closed" or a posted date older than 5 months
 3. Return: list of `{title, company, url, posted_date}` objects — include `posted_date` whenever visible
@@ -267,7 +267,7 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 ## Mode 2: Company Search
 
 1. Search `[company] careers engineering 2026` and `[company] jobs AI ML 2026`
-2. Fetch career page via browser (`mcp__claude-in-chrome__navigate` + `get_page_text`) or Jina Reader as fallback
+2. Fetch career page via browser (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) or Jina Reader as fallback
 3. **Apply freshness filter:** discard any role marked closed/filled or with a posted date older than 5 months. Flag roles with no visible date as `posted_date: unknown`.
 4. List only open, recent roles in a table with `URL` and `Posted` columns (clickable markdown links)
 5. Score each using the multi-dimensional matrix
@@ -326,7 +326,7 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
    ```
    - `questions` non-empty → use them as the authoritative form
    - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
-   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
    - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
 3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
 4. Automatically invoke `find-linkedin-contacts` for this company+role

--- a/.agents/skills/find-kristian-jobs/SKILL.md
+++ b/.agents/skills/find-kristian-jobs/SKILL.md
@@ -20,6 +20,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Script | Purpose |
 |--------|---------|
 | `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Jina Reader → plain curl. |
+| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, questions, form_text}` JSON. Structured questions via Greenhouse/Workable public APIs; apply-page scraping for Lever/generic; Jina for JS-rendered Ashby forms. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Codex in `bypassPermissions` mode and sends a push notification when done. |
 
 ## Search Budget (Hard Limits)
@@ -54,7 +55,9 @@ When parsing a posting with Jina Reader, always look for: `Posted`, `Date posted
 | Search for jobs | `WebSearch` |
 | Fetch career pages (JS-heavy) | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` |
 | Search LinkedIn Jobs (authenticated) | `mcp__claude-in-chrome__*` browser tools |
-| Parse job posting content | `Bash`: `bash .Codex/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
+| Parse job posting content | `Bash`: `bash .agents/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
+| Fetch application form + questions | `Bash`: `bash .agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` |
+| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `get_page_text` on the `apply_url` |
 | Fallback fetch | `WebFetch` |
 
 **URL Caching with qurl — check before every fetch:**
@@ -72,7 +75,7 @@ Applies to: job posting URLs, career page URLs, company about/team pages.
 **Job fetch pattern** — use for every job posting URL. Returns structured JSON with `posted_date` and `status` pre-extracted:
 
 ```bash
-RESULT=$(bash .Codex/skills/find-kristian-jobs/scripts/fetch-job.sh "$JOB_URL")
+RESULT=$(bash .agents/skills/find-kristian-jobs/scripts/fetch-job.sh "$JOB_URL")
 POSTED_DATE=$(echo "$RESULT" | jq -r '.posted_date')   # YYYY-MM-DD or "unknown"
 STATUS=$(echo "$RESULT"     | jq -r '.status')          # "open", "closed", or "unknown"
 CONTENT=$(echo "$RESULT"    | jq -r '.content')
@@ -193,7 +196,7 @@ Collect all results from the 3 agents. Deduplicate by URL. If total > 20, keep t
 
 For each surviving posting, fetch the full content:
 ```bash
-RESULT=$(bash .Codex/skills/find-kristian-jobs/scripts/fetch-job.sh "$JOB_URL")
+RESULT=$(bash .agents/skills/find-kristian-jobs/scripts/fetch-job.sh "$JOB_URL")
 POSTED_DATE=$(echo "$RESULT" | jq -r '.posted_date')
 STATUS=$(echo "$RESULT"     | jq -r '.status')
 CONTENT=$(echo "$RESULT"    | jq -r '.content')
@@ -275,19 +278,22 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 ## Mode 3: Deep Analysis
 
-1. Fetch the full posting: `bash .Codex/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` — returns `{url, posted_date, status, content}` JSON
+1. Fetch the full posting: `bash .agents/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` — returns `{url, posted_date, status, content}` JSON
 2. **Freshness check:** extract the posted date from the parsed content. If the role is closed or older than 5 months, **stop and report** — do not score. If date is unknown, note it and proceed with a warning.
-3. Score with dimension breakdown
-4. Determine positioning frame
-5. Map every requirement to a proof point
-6. Identify gaps honestly
-7. Check for hidden fit signals
-8. Recommend GO / STRETCH / PASS
+3. Fetch the application form: `bash .agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` — capture the `apply_url` and how many custom questions the form carries (this feeds the effort estimate and the Application Package)
+4. Score with dimension breakdown
+5. Determine positioning frame
+6. Map every requirement to a proof point
+7. Identify gaps honestly
+8. Check for hidden fit signals
+9. Recommend GO / STRETCH / PASS
 
 ```
 ## Deep Analysis: [Role] at [Company]
 
 **Job URL**: [link]
+**Apply URL**: [apply deep link or "not found — check manually"]
+**Application Form**: [N custom questions / standard fields only / unreadable (JS or login wall)]
 **Posted Date**: [date or "unknown"]
 **Status**: Open / Closed / Unknown
 **Overall Score**: XX%
@@ -311,9 +317,30 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 ## Mode 4: Application Package
 
+**A job ad is not the application.** The real form — screening questions, essay prompts, salary/visa/notice fields, required attachments — lives on the apply deep link. The package is not complete without it.
+
 1. Run Deep Analysis (Mode 3)
-2. If score >= 60%, generate cover letter + resume talking points + approach angle
-3. Automatically invoke `find-linkedin-contacts` for this company+role
+2. If score >= 60%, fetch the application form:
+   ```bash
+   bash .agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh "$JOB_URL"
+   ```
+   - `questions` non-empty → use them as the authoritative form
+   - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
+   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
+3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
+4. Automatically invoke `find-linkedin-contacts` for this company+role
+
+### Application Form Answers
+
+For every question found in step 2, include a section in the package:
+
+- **Essay/motivation questions** — full drafted answer per the cover letter rules (concrete metrics, honest, tone matched to culture; respect any stated word/character limit)
+- **Factual questions** (salary expectation, notice period, visa/work authorization, start date) — answer from the profile if present; otherwise insert a `[FILL ME: …]` placeholder and list it in the summary — never guess personal facts
+- **Yes/no screeners** — answer honestly from the profile; if an honest answer is a knockout risk, flag it prominently rather than fudging it
+- **Standard fields** (name, email, CV upload, LinkedIn) — list them so nothing is a surprise at submit time; no draft needed
+
+Record the `apply_url` and the form source (api / apply-page / browser / unreadable) at the top of the section.
 
 ### Cover Letter Structure
 1. Opening hook — the most relevant intersection, not generic interest
@@ -355,3 +382,4 @@ Rules: concrete outcomes only, ~350 words, tone matched to culture.
 - When in doubt about positioning, default to "production AI engineer with deep domain expertise in research infrastructure"
 - All searches should include current year to find active postings
 - If a career page is behind authentication or can't be fetched, note this and suggest the user check manually
+- **The job ad is not the application** — for Deep Analysis and Application Package, always resolve the apply deep link and its form questions via `fetch-application-form.sh`; a package without the form's questions (or an explicit unreadable-form note with the `apply_url`) is incomplete

--- a/.agents/skills/find-kristian-jobs/SKILL.md
+++ b/.agents/skills/find-kristian-jobs/SKILL.md
@@ -20,7 +20,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Script | Purpose |
 |--------|---------|
 | `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Jina Reader → plain curl. |
-| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, questions, form_text}` JSON. Structured questions via Greenhouse/Workable public APIs; apply-page scraping for Lever/generic; Jina for JS-rendered Ashby forms. |
+| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON. Structured questions via Greenhouse/Workable/Ashby public APIs; apply-page scraping for Lever/generic. When `needs_browser: true` the form wasn't captured — open `apply_url` with browser tools. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Codex in `bypassPermissions` mode and sends a push notification when done. |
 
 ## Search Budget (Hard Limits)
@@ -324,9 +324,8 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
    ```bash
    bash .agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh "$JOB_URL"
    ```
-   - `questions` non-empty → use them as the authoritative form
-   - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
-   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - `needs_browser: false` and `questions` non-empty → use them as the authoritative form
+   - `needs_browser: true` → the form wasn't captured; open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form (if browser tools are unavailable, extract questions from `form_text`, then try `WebFetch` on `apply_url`)
    - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
 3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
 4. Automatically invoke `find-linkedin-contacts` for this company+role

--- a/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -340,6 +340,7 @@ APPLY_URL=""
 if [[ -n "$HTML" ]]; then
   CAND=$(grep -oiE 'href="[^"]*(apply|application)[^"]*"' <<<"$HTML" \
     | sed -E 's/^[Hh][Rr][Ee][Ff]="//; s/"$//' \
+    | grep -viE '^(mailto:|tel:|javascript:)' \
     | grep -viE '\.(css|js|png|jpg|svg)([?#]|$)' \
     | head -1 || true)
   if [[ -n "${CAND:-}" ]]; then

--- a/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# fetch-application-form.sh — Discover a job posting's application form deep link
+# and extract the questions a candidate must answer to submit a FULL application.
+#
+# A job ad is not the application. Most ATSs put the real form (screening
+# questions, essay prompts, salary/visa/notice fields, required attachments)
+# on a separate apply URL. This script finds that deep link and pulls the
+# questions, structured where the ATS exposes them publicly.
+#
+# Usage:
+#   ./scripts/fetch-application-form.sh <job-url>
+#
+# Output: JSON to stdout
+#   {
+#     "url": "...",          input job posting URL
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "source": "api|apply-page|none",
+#     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
+#     "form_text": "..."     raw apply-page text when questions could not be fully structured
+#   }
+#
+# Strategy per ATS:
+#   greenhouse       → public boards API with ?questions=true (full structured form)
+#   workable         → public form API (v3, then v1)
+#   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
+#   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
+#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   generic          → scan job page HTML for an apply link, fetch it, extract labels
+#
+# The script never fails hard: each strategy degrades to the next, ending with an
+# empty questions list and source "none" so the calling agent knows to open
+# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+#
+# Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
+
+set -uo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo '{"error": "Usage: fetch-application-form.sh <job-url>"}' >&2
+  exit 1
+fi
+
+JINA_KEY="${JINA_API_KEY:-}"
+TIMEOUT=25
+UA="Mozilla/5.0 (compatible; job-application-fetch/1.0)"
+MAX_TEXT=20000
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+fetch() {
+  curl -sfL --max-time "$TIMEOUT" -A "$UA" "$@" 2>/dev/null || true
+}
+
+jina_fetch() {
+  local target="$1"
+  [[ -z "$JINA_KEY" ]] && return 0
+  curl -sf --max-time 45 \
+    -H "Authorization: Bearer ${JINA_KEY}" \
+    -H "X-Return-Format: markdown" \
+    "https://r.jina.ai/${target}" 2>/dev/null || true
+}
+
+strip_html() {
+  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+    | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
+    | sed -E 's/[[:space:]]+/ /g' \
+    | sed '/^[[:space:]]*$/d'
+}
+
+# stdin: raw HTML → candidate form-field labels, one per line
+extract_labels_from_html() {
+  {
+    grep -oE '<label[^>]*>[^<]{3,200}' | sed -E 's/<label[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE '<legend[^>]*>[^<]{3,200}' | sed -E 's/<legend[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE 'aria-label="[^"]{3,200}"' | sed -E 's/^aria-label="//; s/"$//'
+  } <<<"$1" || true
+  {
+    grep -oE 'placeholder="[^"]{3,200}"' | sed -E 's/^placeholder="//; s/"$//'
+  } <<<"$1" || true
+}
+
+# stdin: one label per line → JSON array of question objects
+labels_to_questions_json() {
+  sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g' \
+    | jq -R -s '
+        split("\n")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 2 and length < 300))
+        | unique
+        | map({label: ., type: "unknown", required: null, options: null})' 2>/dev/null \
+    || echo "[]"
+}
+
+emit() {
+  local ats="$1" apply_url="$2" source="$3" questions="$4" form_text="$5"
+  [[ -z "$questions" ]] && questions="[]"
+  jq -n \
+    --arg url "$URL" \
+    --arg ats "$ats" \
+    --arg apply_url "$apply_url" \
+    --arg source "$source" \
+    --argjson questions "$questions" \
+    --arg form_text "$form_text" \
+    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+}
+
+# fetch an apply page and emit best-effort results for a known ATS
+emit_from_apply_page() {
+  local ats="$1" apply_url="$2"
+  local html md
+  html=$(fetch "$apply_url")
+  if [[ -n "$html" ]]; then
+    local labels questions text
+    labels=$(extract_labels_from_html "$html")
+    questions=$(labels_to_questions_json <<<"$labels")
+    text=$(strip_html <<<"$html" | head -c "$MAX_TEXT")
+    emit "$ats" "$apply_url" "apply-page" "$questions" "$text"
+    return 0
+  fi
+  md=$(jina_fetch "$apply_url")
+  if [[ -n "$md" ]]; then
+    emit "$ats" "$apply_url" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$md")"
+    return 0
+  fi
+  emit "$ats" "$apply_url" "none" "[]" ""
+}
+
+# ── Greenhouse ────────────────────────────────────────────────────────────────
+# Public boards API returns the FULL application form via ?questions=true:
+# labels, required flags, field types, and dropdown options — no auth needed.
+# URL patterns: (job-)boards.greenhouse.io/{board}/jobs/{id}, incl. eu. hosts.
+
+if grep -qE 'greenhouse\.io/[^/]+/jobs/[0-9]+' <<<"$URL"; then
+  BOARD=$(grep -oE 'greenhouse\.io/([^/]+)/jobs' <<<"$URL" | cut -d'/' -f2)
+  JOB_ID=$(grep -oE '/jobs/[0-9]+' <<<"$URL" | grep -oE '[0-9]+')
+
+  HOSTS="boards-api.greenhouse.io api.greenhouse.io"
+  grep -q 'eu\.greenhouse\.io' <<<"$URL" && HOSTS="boards-api.eu.greenhouse.io $HOSTS"
+
+  for HOST in $HOSTS; do
+    RESPONSE=$(fetch "https://${HOST}/v1/boards/${BOARD}/jobs/${JOB_ID}?questions=true")
+    if [[ -n "$RESPONSE" ]] && jq -e '.id' <<<"$RESPONSE" >/dev/null 2>&1; then
+      APPLY_URL=$(jq -r '.absolute_url // ""' <<<"$RESPONSE")
+      [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+      APPLY_URL="${APPLY_URL}#app"
+      QUESTIONS=$(jq '
+        [ (.questions // [])[],
+          ((.compliance // [])[] | (.questions // [])[]),
+          ((.demographic_questions.questions // [])[]) ]
+        | map({
+            label: (.label // ""),
+            type: (.fields[0].type // .type // "unknown"),
+            required: (.required // null),
+            options: ((.fields[0].values // .answer_options // [])
+                      | map(.label // .name // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      emit "greenhouse" "$APPLY_URL" "api" "${QUESTIONS:-[]}" ""
+      exit 0
+    fi
+  done
+
+  # API unreachable — fall back to reading the posting page itself
+  emit_from_apply_page "greenhouse" "${URL}#app"
+  exit 0
+fi
+
+# ── Workable ─────────────────────────────────────────────────────────────────
+# apply.workable.com exposes the application form definition as JSON.
+# URL pattern: apply.workable.com/{account}/j/{SHORTCODE}
+
+if grep -qE 'apply\.workable\.com/[^/]+/j/[A-Za-z0-9]+' <<<"$URL"; then
+  ACCOUNT=$(sed -E 's|.*apply\.workable\.com/([^/]+)/j/.*|\1|' <<<"$URL")
+  SHORTCODE=$(sed -E 's|.*/j/([A-Za-z0-9]+).*|\1|' <<<"$URL")
+  APPLY_URL="https://apply.workable.com/${ACCOUNT}/j/${SHORTCODE}/apply/"
+
+  for V in v3 v1; do
+    RESPONSE=$(fetch "https://apply.workable.com/api/${V}/accounts/${ACCOUNT}/jobs/${SHORTCODE}/form")
+    if [[ -n "$RESPONSE" ]] && jq -e 'type == "object"' <<<"$RESPONSE" >/dev/null 2>&1; then
+      QUESTIONS=$(jq '
+        [ ((.fields // [])[]), ((.questions // [])[]) ]
+        | map({
+            label: (.label // .body // .key // ""),
+            type: (.type // "unknown"),
+            required: (.required // null),
+            options: ((.options // .choices // [])
+                      | map(.body // .value // .label // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+        emit "workable" "$APPLY_URL" "api" "$QUESTIONS" ""
+        exit 0
+      fi
+    fi
+  done
+
+  emit_from_apply_page "workable" "$APPLY_URL"
+  exit 0
+fi
+
+# ── Lever ────────────────────────────────────────────────────────────────────
+# The apply form lives at {posting-url}/apply and is server-rendered, so custom
+# questions appear directly in the HTML. URL: jobs.(eu.)lever.co/{company}/{uuid}
+
+if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/apply}"
+  emit_from_apply_page "lever" "${BASE}/apply"
+  exit 0
+fi
+
+# ── Ashby ────────────────────────────────────────────────────────────────────
+# Apply form at {posting-url}/application; the page is client-rendered, so only
+# Jina Reader (which executes JS) can read it non-interactively.
+
+if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/application}"
+  APPLY_URL="${BASE}/application"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "ashby" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── SmartRecruiters ──────────────────────────────────────────────────────────
+# Public postings API gives the canonical applyUrl; the form itself is JS-heavy.
+
+if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
+  COMPANY=$(sed -E 's|.*jobs\.smartrecruiters\.com/([^/]+).*|\1|' <<<"$URL")
+  POSTING_ID=$(grep -oE '/[0-9]{9,}' <<<"$URL" | grep -oE '[0-9]+' | head -1 || true)
+  APPLY_URL=""
+  if [[ -n "${POSTING_ID:-}" ]]; then
+    RESPONSE=$(fetch "https://api.smartrecruiters.com/v1/companies/${COMPANY}/postings/${POSTING_ID}")
+    APPLY_URL=$(jq -r '.applyUrl // ""' <<<"$RESPONSE" 2>/dev/null || true)
+  fi
+  [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Generic ──────────────────────────────────────────────────────────────────
+# Fetch the job page, look for an apply/application link, follow it, and
+# extract whatever field labels are visible.
+
+HTML=$(fetch "$URL")
+APPLY_URL=""
+if [[ -n "$HTML" ]]; then
+  CAND=$(grep -oiE 'href="[^"]*(apply|application)[^"]*"' <<<"$HTML" \
+    | sed -E 's/^[Hh][Rr][Ee][Ff]="//; s/"$//' \
+    | grep -viE '\.(css|js|png|jpg|svg)([?#]|$)' \
+    | head -1 || true)
+  if [[ -n "${CAND:-}" ]]; then
+    case "$CAND" in
+      http*)  APPLY_URL="$CAND" ;;
+      //*)    APPLY_URL="https:${CAND}" ;;
+      /*)     ORIGIN=$(sed -E 's|^(https?://[^/]+).*|\1|' <<<"$URL"); APPLY_URL="${ORIGIN}${CAND}" ;;
+      *)      APPLY_URL="${URL%/}/${CAND}" ;;
+    esac
+  fi
+fi
+
+if [[ -n "$APPLY_URL" ]]; then
+  emit_from_apply_page "generic" "$APPLY_URL"
+  exit 0
+fi
+
+# No apply link found — return the job page text so the agent can look for
+# embedded questions, and signal that a browser is needed for the form.
+if [[ -n "$HTML" ]]; then
+  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+else
+  MD=$(jina_fetch "$URL")
+  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+fi

--- a/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -13,24 +13,32 @@
 # Output: JSON to stdout
 #   {
 #     "url": "...",          input job posting URL
-#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|factorial|generic",
 #     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
+#     "needs_browser": true|false,  true when the form wasn't captured (source apply-page/none AND questions empty)
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
 #   }
+#
+# needs_browser is the handoff signal: when true, the returned questions are empty
+# and form_text is at best a thin JD blob, so the calling agent MUST open apply_url
+# with browser tools (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text)
+# to read the real form instead of trusting this output. When false, questions[] is
+# authoritative and no browser step is needed.
 #
 # Strategy per ATS:
 #   greenhouse       → public boards API with ?questions=true (full structured form)
 #   workable         → public form API (v3, then v1)
 #   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
 #   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
-#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   ashby            → public GraphQL posting API (full structured form); Jina Reader fallback
+#   factorial        → detect factorialhr.com, surface apply_url, hand off to browser
 #   generic          → scan job page HTML for an apply link, fetch it, extract labels
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
-# empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
+# empty questions list, source "none", and needs_browser true so the calling agent
+# knows to open apply_url in a browser instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -107,7 +115,15 @@ emit() {
     --arg source "$source" \
     --argjson questions "$questions" \
     --arg form_text "$form_text" \
-    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+    '{
+       url: $url,
+       ats: $ats,
+       apply_url: $apply_url,
+       source: $source,
+       needs_browser: (($source == "apply-page" or $source == "none") and ($questions | length) == 0),
+       questions: $questions,
+       form_text: $form_text
+     }'
 }
 
 # fetch an apply page and emit best-effort results for a known ATS
@@ -219,14 +235,52 @@ if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
 fi
 
 # ── Ashby ────────────────────────────────────────────────────────────────────
-# Apply form at {posting-url}/application; the page is client-rendered, so only
-# Jina Reader (which executes JS) can read it non-interactively.
+# Ashby exposes a public GraphQL endpoint (non-user-graphql, ApiJobPosting) that
+# returns the FULL application form — sections → fieldEntries → field — structured
+# and unauthenticated, just like Greenhouse. The apply page itself is client-
+# rendered JS, so Jina Reader is only a text fallback when the API path fails.
+# URL: jobs.ashbyhq.com/{org}/{jobPostingId}[/application]
 
 if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
   BASE="${URL%%\?*}"
   BASE="${BASE%/}"
   BASE="${BASE%/application}"
   APPLY_URL="${BASE}/application"
+  ORG=$(sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|' <<<"$BASE")
+  JOB_ID=$(sed -E 's|.*/([A-Za-z0-9-]+)$|\1|' <<<"$BASE")
+
+  GQL=$(jq -n --arg org "$ORG" --arg jid "$JOB_ID" '{
+    operationName: "ApiJobPosting",
+    variables: {organizationHostedJobsPageName: $org, jobPostingId: $jid},
+    query: "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { applicationForm { sections { title fieldEntries { isRequired field } } } } }"
+  }')
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+    -H "Content-Type: application/json" \
+    -H "Origin: https://jobs.ashbyhq.com" \
+    --data-raw "$GQL" \
+    "https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting" 2>/dev/null || true)
+
+  if [[ -n "$RESPONSE" ]] && jq -e '.data.jobPosting.applicationForm.sections' <<<"$RESPONSE" >/dev/null 2>&1; then
+    # field is a JSON scalar carrying {title, type, selectableValues, ...}
+    QUESTIONS=$(jq '
+      [ (.data.jobPosting.applicationForm.sections // [])[]
+        | (.fieldEntries // [])[]
+        | {
+            label: (.field.title // ""),
+            type: (.field.type // "unknown"),
+            required: (.isRequired // null),
+            options: ((.field.selectableValues // [])
+                      | map(.label // .value // tostring)
+                      | if length == 0 then null else . end)
+          } ]
+      | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+    if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+      emit "ashby" "$APPLY_URL" "api" "$QUESTIONS" ""
+      exit 0
+    fi
+  fi
+
+  # API path failed — degrade to Jina Reader text, then to a bare browser handoff.
   MD=$(jina_fetch "$APPLY_URL")
   if [[ -n "$MD" ]]; then
     emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
@@ -253,6 +307,26 @@ if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
     emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
   else
     emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Factorial ────────────────────────────────────────────────────────────────
+# Factorial self-hosts job boards on {company}.factorialhr.com. The apply form is
+# client-rendered with no known public form endpoint, so surface a sensible
+# apply_url plus the job-page text and hand the form off to a browser.
+# URL: {company}.factorialhr.com/job_posting/{slug}  (or /jobs/...)
+
+if grep -qE 'factorialhr\.com' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  APPLY_URL="$BASE"
+  HTML=$(fetch "$URL")
+  if [[ -n "$HTML" ]]; then
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  else
+    MD=$(jina_fetch "$URL")
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
   fi
   exit 0
 fi

--- a/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -14,7 +14,7 @@
 #   {
 #     "url": "...",          input job posting URL
 #     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
-#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
@@ -30,7 +30,7 @@
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
 # empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -286,8 +286,8 @@ fi
 # No apply link found — return the job page text so the agent can look for
 # embedded questions, and signal that a browser is needed for the form.
 if [[ -n "$HTML" ]]; then
-  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  emit "generic" "$URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
 else
   MD=$(jina_fetch "$URL")
-  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+  emit "generic" "$URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
 fi

--- a/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.agents/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -63,7 +63,7 @@ jina_fetch() {
 }
 
 strip_html() {
-  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+  perl -0777 -pe 's{<script\b[^>]*>.*?</script>}{}gis; s{<style\b[^>]*>.*?</style>}{}gis; s{<[^>]*>}{ }g' \
     | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
     | sed -E 's/[[:space:]]+/ /g' \
     | sed '/^[[:space:]]*$/d'

--- a/.agents/skills/generate-application/SKILL.md
+++ b/.agents/skills/generate-application/SKILL.md
@@ -42,7 +42,7 @@ Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script 
 Interpret the result:
 - **`questions` non-empty** — use them directly; they are the authoritative form.
 - **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
-- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `get_page_text`), open `apply_url` and read the rendered form.
+- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`), open `apply_url` and read the rendered form.
 - **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
 
 Classify each question into three buckets (used in Step 9):

--- a/.agents/skills/generate-application/SKILL.md
+++ b/.agents/skills/generate-application/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: generate-application
-description: This skill should be used when the user says "apply for [job URL]", "generate application for", "prepare my CV for", "create application package for", "write a cover letter for", or provides a job posting URL and wants to apply. Generates a full application package — targeted CV data file, analysis, and cover letter — saved under applications/[company]-[role]/ in the project root.
-version: 0.1.0
+description: This skill should be used when the user says "apply for [job URL]", "generate application for", "prepare my CV for", "create application package for", "write a cover letter for", or provides a job posting URL and wants to apply. Generates a full application package — targeted CV data file, analysis, application form answers, and cover letter — saved under applications/[company]-[role]/ in the project root.
+version: 0.2.0
 argument-hint: "[job-url]"
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent", "WebFetch"]
 ---
 
 # generate-application
 
-Generate a complete, targeted application package for a job posting. The output lives at `applications/YYYY-MM-DD-[company]-[role-slug]/` in the project root and includes a deep analysis, a targeted CV data file, and a two-paragraph cover letter.
+Generate a complete, targeted application package for a job posting. The output lives at `applications/YYYY-MM-DD-[company]-[role-slug]/` in the project root and includes a deep analysis, a targeted CV data file, drafted answers to the actual application form questions, and a two-paragraph cover letter.
+
+**A job ad is not the application.** The real application lives on a separate apply deep link (Greenhouse `#app` form, Lever `/apply`, Ashby `/application`, Workable apply page, …) with screening questions, essay prompts, and factual fields the ad never mentions. A package that skips these is incomplete — Step 2 is mandatory, not optional.
 
 ## Step 1 — Fetch and Parse the Job Posting
 
@@ -27,22 +29,43 @@ Extract from the posting:
 - Work arrangement (remote, hybrid, location)
 - Mission/culture signals
 
-## Step 2 — Read Kristian's Profile
+## Step 2 — Fetch the Application Form (Deep Link) and Extract Questions
+
+Discover the apply deep link and pull the actual application questions:
+
+```bash
+bash .agents/skills/generate-application/scripts/fetch-application-form.sh "[job-url]"
+```
+
+Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API — both return labels, required flags, and dropdown options) and falls back to scraping the apply page.
+
+Interpret the result:
+- **`questions` non-empty** — use them directly; they are the authoritative form.
+- **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
+- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `get_page_text`), open `apply_url` and read the rendered form.
+- **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
+
+Classify each question into three buckets (used in Step 9):
+1. **Essay/motivation questions** ("Why do you want to work here?", "Describe a project…") — these need drafted answers.
+2. **Factual questions** (salary expectation, notice period, visa/work authorization, start date, location, years of experience) — answer from the profile where possible.
+3. **Standard fields** (name, email, phone, CV/resume upload, LinkedIn URL) — list them so nothing is a surprise, but no draft needed.
+
+## Step 3 — Read Kristian's Profile
 
 Read the full candidate profile before scoring:
 
 ```
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/kristian-profile.md
+.agents/skills/generate-application/references/kristian-profile.md
 ```
 
 Also read the scoring matrix and tone/voice reference:
 
 ```
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/scoring-matrix.md
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/tone-and-voice.md
+.agents/skills/generate-application/references/scoring-matrix.md
+.agents/skills/generate-application/references/tone-and-voice.md
 ```
 
-## Step 3 — Score and Analyze
+## Step 4 — Score and Analyze
 
 Apply the multi-dimensional scoring matrix (see `references/scoring-matrix.md`).
 
@@ -56,7 +79,7 @@ Produce for `analysis.md`:
 
 If score < 60% (PASS), tell the user and stop — do not generate a cover letter or CV data for a role with poor fit.
 
-## Step 4 — Determine Output Slug
+## Step 5 — Determine Output Slug
 
 Derive folder name:
 - `company`: lowercase, no spaces, no punctuation (e.g. `iris`, `deepmind`)
@@ -66,15 +89,15 @@ Derive folder name:
 
 The `applications/` directory lives in the project root. Create it (and the slug subfolder) if it doesn't exist.
 
-## Step 5 — Save job-posting.md
+## Step 6 — Save job-posting.md
 
-Write the raw parsed job description to `applications/[slug]/job-posting.md`.
+Write the raw parsed job description to `applications/[slug]/job-posting.md`. Include the `apply_url` from Step 2 at the top.
 
-## Step 6 — Save analysis.md
+## Step 7 — Save analysis.md
 
-Write the full analysis (Step 3 output) to `applications/[slug]/analysis.md`.
+Write the full analysis (Step 4 output) to `applications/[slug]/analysis.md`.
 
-## Step 7 — Generate cv-data.js
+## Step 8 — Generate cv-data.js
 
 Generate a targeted CV data file for this role. This is a CommonJS module that exports an object matching the schema in `src/_data/cvIris.js` (the canonical example of a targeted CV variant — use this as the schema reference, not `src/_data/cv.js`).
 
@@ -82,7 +105,7 @@ Apply tone and voice guidance from `references/tone-and-voice.md` when writing t
 
 Reframe employment bullets, profile statement, and skill rankings to match:
 - The role's tech stack (prioritise skills they listed first)
-- The positioning frame chosen in Step 3
+- The positioning frame chosen in Step 4
 - Concrete proof points with metrics from `references/kristian-profile.md`
 - Honest language — do not invent technologies or claim expertise not in the profile
 
@@ -92,27 +115,59 @@ Also print instructions for the user to integrate it:
 1. Copy `cv-data.js` → `src/_data/cv[Company].js` (camelCase, e.g. `cvDeepMind.js`, `cvCrossref.js`)
 2. Rebuild: `bun run build`
 
-## Step 8 — Generate Cover Letter via Agent
+## Step 9 — Draft application-questions.md
+
+Write `applications/[slug]/application-questions.md` covering **every** question found in Step 2, grouped by bucket:
+
+```markdown
+# Application Form: [Role] at [Company]
+
+**Apply URL**: [apply_url]
+**Form source**: api / apply-page / manual (browser) / unreadable
+
+## Essay & Motivation Questions
+### Q: [question text] (required, max N words if stated)
+[Drafted answer — tone-and-voice rules, concrete proof points with metrics,
+respect any stated word/character limit, honest.]
+
+## Factual Questions
+| Question | Answer |
+|----------|--------|
+| [e.g. Notice period] | [from profile, or `[FILL ME: notice period]`] |
+
+## Standard Fields (no draft needed)
+- Name, email, CV upload, ...
+```
+
+Rules:
+- Draft essay answers with the same voice rules as the cover letter (`references/tone-and-voice.md`) — no em dashes, no invented experience.
+- For yes/no screeners, answer honestly from the profile. If an honest answer is a knockout risk (e.g. "Do you have X?" and the profile says no), flag it prominently rather than fudging it.
+- For personal facts not in the profile (salary expectation, notice period, visa status, earliest start date), insert a `[FILL ME: …]` placeholder — never guess.
+- If the form could not be read at all, this file must still exist, containing the `apply_url` and a note telling the user to check the form manually before submitting.
+
+## Step 10 — Generate Cover Letter via Agent
 
 Dispatch the `cover-letter-writer` agent with:
 - The job posting content
 - The analysis (positioning frame, top 3 proof points, gaps)
 - The company name and role title
+- Any essay questions from Step 2 that overlap with cover letter territory (so the letter and the form answers complement rather than repeat each other)
 
 The agent returns a greeting line, a two-paragraph cover letter body in a warm, helpful, audience-first tone, and a concise close line (for example, "Sincerely,"). It avoids em dashes in output and does not force a first-90-days commitment. Save to `applications/[slug]/cover-letter.md`.
 
 Invoke using the Agent tool with subagent_type matching the `cover-letter-writer` agent. Pass all context in the prompt.
 
-## Step 9 — Write README.md
+## Step 11 — Write README.md
 
-Write `applications/[slug]/README.md` using the template in `references/output-structure.md`. Status should be `Draft` by default.
+Write `applications/[slug]/README.md` using the template in `references/output-structure.md`. Status should be `Draft` by default. Include the `apply_url` and list any `[FILL ME]` placeholders still open.
 
-## Step 10 — Present Summary
+## Step 12 — Present Summary
 
 Tell the user:
 - Score and recommendation
 - Folder path where files were saved
 - Which files were generated
+- The apply deep link, how many form questions were found, and any `[FILL ME]` placeholders that need their input before submitting
 - How to integrate `cv-data.js` into the site
 - One-line suggested email subject line for the application
 
@@ -123,9 +178,14 @@ Tell the user:
 - **`references/output-structure.md`** — Folder layout, file formats, and integration steps
 - **`references/tone-and-voice.md`** — Voice rules for cover letter, CV profile, and employment bullets
 
+## Scripts
+
+- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, and generic career pages.
+
 ## Notes
 
 - Always read the full posting before scoring — do not assume from job title alone
 - Be honest about gaps — authenticity over overselling
 - The cover letter body must be exactly 2 paragraphs. The agent enforces this.
+- The package is not complete without `application-questions.md` — either with the form's questions answered, or with an explicit note that the form is behind a login/JS wall and must be checked manually
 - If the job URL redirects or is behind a wall, ask the user to paste the posting text directly

--- a/.agents/skills/generate-application/SKILL.md
+++ b/.agents/skills/generate-application/SKILL.md
@@ -37,12 +37,11 @@ Discover the apply deep link and pull the actual application questions:
 bash .agents/skills/generate-application/scripts/fetch-application-form.sh "[job-url]"
 ```
 
-Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API — both return labels, required flags, and dropdown options) and falls back to scraping the apply page.
+Returns JSON: `{url, ats, apply_url, source, needs_browser, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API, Ashby GraphQL posting API — all return labels, required flags, and dropdown options) and falls back to scraping the apply page.
 
 Interpret the result:
-- **`questions` non-empty** — use them directly; they are the authoritative form.
-- **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
-- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`), open `apply_url` and read the rendered form.
+- **`needs_browser: false`** — `questions` is authoritative; use it directly.
+- **`needs_browser: true`** — the form wasn't captured (empty `questions`; `form_text` is at best a thin JD blob). Open `apply_url` with browser tools (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) and read the rendered form. If browser tools are unavailable, extract whatever you can from `form_text`, then try `WebFetch` on `apply_url`.
 - **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
 
 Classify each question into three buckets (used in Step 9):
@@ -180,7 +179,7 @@ Tell the user:
 
 ## Scripts
 
-- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, and generic career pages.
+- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, Factorial, and generic career pages. `needs_browser: true` signals the form must be read with browser tools.
 
 ## Notes
 

--- a/.agents/skills/generate-application/references/output-structure.md
+++ b/.agents/skills/generate-application/references/output-structure.md
@@ -7,12 +7,23 @@ Each application generates a folder at `applications/YYYY-MM-DD-[company]-[role-
 ```
 applications/
   YYYY-MM-DD-[company]-[role-slug]/
-    README.md           ← One-line summary: company, role, score, status
-    job-posting.md      ← Raw parsed job description (from Jina)
-    analysis.md         ← Deep analysis: score breakdown, gap mapping, positioning
-    cover-letter.md     ← Final cover letter (greeting + 2 body paragraphs + concise close)
-    cv-data.js          ← CV data file ready to drop into src/_data/
+    README.md                 ← One-line summary: company, role, score, status, apply URL
+    job-posting.md            ← Raw parsed job description (from Jina), apply URL at top
+    analysis.md               ← Deep analysis: score breakdown, gap mapping, positioning
+    application-questions.md  ← Every question from the actual apply form, with drafted answers
+    cover-letter.md           ← Final cover letter (greeting + 2 body paragraphs + concise close)
+    cv-data.js                ← CV data file ready to drop into src/_data/
 ```
+
+## application-questions.md
+
+Sourced from the apply deep link (Greenhouse `#app`, Lever `/apply`, Ashby `/application`, Workable apply page), not the job ad. Three sections:
+
+1. **Essay & Motivation Questions** — full drafted answers, tone-and-voice compliant
+2. **Factual Questions** — table of question → answer; unknowns marked `[FILL ME: …]`
+3. **Standard Fields** — plain list (name, email, CV upload, …), no drafts
+
+If the form was unreadable (login/JS wall), the file still exists with the apply URL and a manual-check note.
 
 ## cv-data.js
 
@@ -40,6 +51,9 @@ The site will pick up the new CV data automatically.
 | Company | [Company] |
 | Role | [Role Title] |
 | URL | [Job URL] |
+| Apply URL | [apply deep link from fetch-application-form.sh] |
+| Form questions | [N found / unreadable — check manually] |
+| Open placeholders | [list of `[FILL ME]` items, or "none"] |
 | Date | [YYYY-MM-DD] |
 | Score | [XX]% |
 | Status | Applied / Draft / Rejected / Interview |

--- a/.agents/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.agents/skills/generate-application/scripts/fetch-application-form.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# fetch-application-form.sh — Discover a job posting's application form deep link
+# and extract the questions a candidate must answer to submit a FULL application.
+#
+# A job ad is not the application. Most ATSs put the real form (screening
+# questions, essay prompts, salary/visa/notice fields, required attachments)
+# on a separate apply URL. This script finds that deep link and pulls the
+# questions, structured where the ATS exposes them publicly.
+#
+# Usage:
+#   ./scripts/fetch-application-form.sh <job-url>
+#
+# Output: JSON to stdout
+#   {
+#     "url": "...",          input job posting URL
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "source": "api|apply-page|none",
+#     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
+#     "form_text": "..."     raw apply-page text when questions could not be fully structured
+#   }
+#
+# Strategy per ATS:
+#   greenhouse       → public boards API with ?questions=true (full structured form)
+#   workable         → public form API (v3, then v1)
+#   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
+#   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
+#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   generic          → scan job page HTML for an apply link, fetch it, extract labels
+#
+# The script never fails hard: each strategy degrades to the next, ending with an
+# empty questions list and source "none" so the calling agent knows to open
+# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+#
+# Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
+
+set -uo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo '{"error": "Usage: fetch-application-form.sh <job-url>"}' >&2
+  exit 1
+fi
+
+JINA_KEY="${JINA_API_KEY:-}"
+TIMEOUT=25
+UA="Mozilla/5.0 (compatible; job-application-fetch/1.0)"
+MAX_TEXT=20000
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+fetch() {
+  curl -sfL --max-time "$TIMEOUT" -A "$UA" "$@" 2>/dev/null || true
+}
+
+jina_fetch() {
+  local target="$1"
+  [[ -z "$JINA_KEY" ]] && return 0
+  curl -sf --max-time 45 \
+    -H "Authorization: Bearer ${JINA_KEY}" \
+    -H "X-Return-Format: markdown" \
+    "https://r.jina.ai/${target}" 2>/dev/null || true
+}
+
+strip_html() {
+  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+    | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
+    | sed -E 's/[[:space:]]+/ /g' \
+    | sed '/^[[:space:]]*$/d'
+}
+
+# stdin: raw HTML → candidate form-field labels, one per line
+extract_labels_from_html() {
+  {
+    grep -oE '<label[^>]*>[^<]{3,200}' | sed -E 's/<label[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE '<legend[^>]*>[^<]{3,200}' | sed -E 's/<legend[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE 'aria-label="[^"]{3,200}"' | sed -E 's/^aria-label="//; s/"$//'
+  } <<<"$1" || true
+  {
+    grep -oE 'placeholder="[^"]{3,200}"' | sed -E 's/^placeholder="//; s/"$//'
+  } <<<"$1" || true
+}
+
+# stdin: one label per line → JSON array of question objects
+labels_to_questions_json() {
+  sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g' \
+    | jq -R -s '
+        split("\n")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 2 and length < 300))
+        | unique
+        | map({label: ., type: "unknown", required: null, options: null})' 2>/dev/null \
+    || echo "[]"
+}
+
+emit() {
+  local ats="$1" apply_url="$2" source="$3" questions="$4" form_text="$5"
+  [[ -z "$questions" ]] && questions="[]"
+  jq -n \
+    --arg url "$URL" \
+    --arg ats "$ats" \
+    --arg apply_url "$apply_url" \
+    --arg source "$source" \
+    --argjson questions "$questions" \
+    --arg form_text "$form_text" \
+    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+}
+
+# fetch an apply page and emit best-effort results for a known ATS
+emit_from_apply_page() {
+  local ats="$1" apply_url="$2"
+  local html md
+  html=$(fetch "$apply_url")
+  if [[ -n "$html" ]]; then
+    local labels questions text
+    labels=$(extract_labels_from_html "$html")
+    questions=$(labels_to_questions_json <<<"$labels")
+    text=$(strip_html <<<"$html" | head -c "$MAX_TEXT")
+    emit "$ats" "$apply_url" "apply-page" "$questions" "$text"
+    return 0
+  fi
+  md=$(jina_fetch "$apply_url")
+  if [[ -n "$md" ]]; then
+    emit "$ats" "$apply_url" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$md")"
+    return 0
+  fi
+  emit "$ats" "$apply_url" "none" "[]" ""
+}
+
+# ── Greenhouse ────────────────────────────────────────────────────────────────
+# Public boards API returns the FULL application form via ?questions=true:
+# labels, required flags, field types, and dropdown options — no auth needed.
+# URL patterns: (job-)boards.greenhouse.io/{board}/jobs/{id}, incl. eu. hosts.
+
+if grep -qE 'greenhouse\.io/[^/]+/jobs/[0-9]+' <<<"$URL"; then
+  BOARD=$(grep -oE 'greenhouse\.io/([^/]+)/jobs' <<<"$URL" | cut -d'/' -f2)
+  JOB_ID=$(grep -oE '/jobs/[0-9]+' <<<"$URL" | grep -oE '[0-9]+')
+
+  HOSTS="boards-api.greenhouse.io api.greenhouse.io"
+  grep -q 'eu\.greenhouse\.io' <<<"$URL" && HOSTS="boards-api.eu.greenhouse.io $HOSTS"
+
+  for HOST in $HOSTS; do
+    RESPONSE=$(fetch "https://${HOST}/v1/boards/${BOARD}/jobs/${JOB_ID}?questions=true")
+    if [[ -n "$RESPONSE" ]] && jq -e '.id' <<<"$RESPONSE" >/dev/null 2>&1; then
+      APPLY_URL=$(jq -r '.absolute_url // ""' <<<"$RESPONSE")
+      [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+      APPLY_URL="${APPLY_URL}#app"
+      QUESTIONS=$(jq '
+        [ (.questions // [])[],
+          ((.compliance // [])[] | (.questions // [])[]),
+          ((.demographic_questions.questions // [])[]) ]
+        | map({
+            label: (.label // ""),
+            type: (.fields[0].type // .type // "unknown"),
+            required: (.required // null),
+            options: ((.fields[0].values // .answer_options // [])
+                      | map(.label // .name // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      emit "greenhouse" "$APPLY_URL" "api" "${QUESTIONS:-[]}" ""
+      exit 0
+    fi
+  done
+
+  # API unreachable — fall back to reading the posting page itself
+  emit_from_apply_page "greenhouse" "${URL}#app"
+  exit 0
+fi
+
+# ── Workable ─────────────────────────────────────────────────────────────────
+# apply.workable.com exposes the application form definition as JSON.
+# URL pattern: apply.workable.com/{account}/j/{SHORTCODE}
+
+if grep -qE 'apply\.workable\.com/[^/]+/j/[A-Za-z0-9]+' <<<"$URL"; then
+  ACCOUNT=$(sed -E 's|.*apply\.workable\.com/([^/]+)/j/.*|\1|' <<<"$URL")
+  SHORTCODE=$(sed -E 's|.*/j/([A-Za-z0-9]+).*|\1|' <<<"$URL")
+  APPLY_URL="https://apply.workable.com/${ACCOUNT}/j/${SHORTCODE}/apply/"
+
+  for V in v3 v1; do
+    RESPONSE=$(fetch "https://apply.workable.com/api/${V}/accounts/${ACCOUNT}/jobs/${SHORTCODE}/form")
+    if [[ -n "$RESPONSE" ]] && jq -e 'type == "object"' <<<"$RESPONSE" >/dev/null 2>&1; then
+      QUESTIONS=$(jq '
+        [ ((.fields // [])[]), ((.questions // [])[]) ]
+        | map({
+            label: (.label // .body // .key // ""),
+            type: (.type // "unknown"),
+            required: (.required // null),
+            options: ((.options // .choices // [])
+                      | map(.body // .value // .label // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+        emit "workable" "$APPLY_URL" "api" "$QUESTIONS" ""
+        exit 0
+      fi
+    fi
+  done
+
+  emit_from_apply_page "workable" "$APPLY_URL"
+  exit 0
+fi
+
+# ── Lever ────────────────────────────────────────────────────────────────────
+# The apply form lives at {posting-url}/apply and is server-rendered, so custom
+# questions appear directly in the HTML. URL: jobs.(eu.)lever.co/{company}/{uuid}
+
+if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/apply}"
+  emit_from_apply_page "lever" "${BASE}/apply"
+  exit 0
+fi
+
+# ── Ashby ────────────────────────────────────────────────────────────────────
+# Apply form at {posting-url}/application; the page is client-rendered, so only
+# Jina Reader (which executes JS) can read it non-interactively.
+
+if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/application}"
+  APPLY_URL="${BASE}/application"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "ashby" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── SmartRecruiters ──────────────────────────────────────────────────────────
+# Public postings API gives the canonical applyUrl; the form itself is JS-heavy.
+
+if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
+  COMPANY=$(sed -E 's|.*jobs\.smartrecruiters\.com/([^/]+).*|\1|' <<<"$URL")
+  POSTING_ID=$(grep -oE '/[0-9]{9,}' <<<"$URL" | grep -oE '[0-9]+' | head -1 || true)
+  APPLY_URL=""
+  if [[ -n "${POSTING_ID:-}" ]]; then
+    RESPONSE=$(fetch "https://api.smartrecruiters.com/v1/companies/${COMPANY}/postings/${POSTING_ID}")
+    APPLY_URL=$(jq -r '.applyUrl // ""' <<<"$RESPONSE" 2>/dev/null || true)
+  fi
+  [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Generic ──────────────────────────────────────────────────────────────────
+# Fetch the job page, look for an apply/application link, follow it, and
+# extract whatever field labels are visible.
+
+HTML=$(fetch "$URL")
+APPLY_URL=""
+if [[ -n "$HTML" ]]; then
+  CAND=$(grep -oiE 'href="[^"]*(apply|application)[^"]*"' <<<"$HTML" \
+    | sed -E 's/^[Hh][Rr][Ee][Ff]="//; s/"$//' \
+    | grep -viE '\.(css|js|png|jpg|svg)([?#]|$)' \
+    | head -1 || true)
+  if [[ -n "${CAND:-}" ]]; then
+    case "$CAND" in
+      http*)  APPLY_URL="$CAND" ;;
+      //*)    APPLY_URL="https:${CAND}" ;;
+      /*)     ORIGIN=$(sed -E 's|^(https?://[^/]+).*|\1|' <<<"$URL"); APPLY_URL="${ORIGIN}${CAND}" ;;
+      *)      APPLY_URL="${URL%/}/${CAND}" ;;
+    esac
+  fi
+fi
+
+if [[ -n "$APPLY_URL" ]]; then
+  emit_from_apply_page "generic" "$APPLY_URL"
+  exit 0
+fi
+
+# No apply link found — return the job page text so the agent can look for
+# embedded questions, and signal that a browser is needed for the form.
+if [[ -n "$HTML" ]]; then
+  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+else
+  MD=$(jina_fetch "$URL")
+  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+fi

--- a/.agents/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.agents/skills/generate-application/scripts/fetch-application-form.sh
@@ -13,24 +13,32 @@
 # Output: JSON to stdout
 #   {
 #     "url": "...",          input job posting URL
-#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|factorial|generic",
 #     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
+#     "needs_browser": true|false,  true when the form wasn't captured (source apply-page/none AND questions empty)
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
 #   }
+#
+# needs_browser is the handoff signal: when true, the returned questions are empty
+# and form_text is at best a thin JD blob, so the calling agent MUST open apply_url
+# with browser tools (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text)
+# to read the real form instead of trusting this output. When false, questions[] is
+# authoritative and no browser step is needed.
 #
 # Strategy per ATS:
 #   greenhouse       → public boards API with ?questions=true (full structured form)
 #   workable         → public form API (v3, then v1)
 #   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
 #   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
-#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   ashby            → public GraphQL posting API (full structured form); Jina Reader fallback
+#   factorial        → detect factorialhr.com, surface apply_url, hand off to browser
 #   generic          → scan job page HTML for an apply link, fetch it, extract labels
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
-# empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
+# empty questions list, source "none", and needs_browser true so the calling agent
+# knows to open apply_url in a browser instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -107,7 +115,15 @@ emit() {
     --arg source "$source" \
     --argjson questions "$questions" \
     --arg form_text "$form_text" \
-    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+    '{
+       url: $url,
+       ats: $ats,
+       apply_url: $apply_url,
+       source: $source,
+       needs_browser: (($source == "apply-page" or $source == "none") and ($questions | length) == 0),
+       questions: $questions,
+       form_text: $form_text
+     }'
 }
 
 # fetch an apply page and emit best-effort results for a known ATS
@@ -219,14 +235,52 @@ if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
 fi
 
 # ── Ashby ────────────────────────────────────────────────────────────────────
-# Apply form at {posting-url}/application; the page is client-rendered, so only
-# Jina Reader (which executes JS) can read it non-interactively.
+# Ashby exposes a public GraphQL endpoint (non-user-graphql, ApiJobPosting) that
+# returns the FULL application form — sections → fieldEntries → field — structured
+# and unauthenticated, just like Greenhouse. The apply page itself is client-
+# rendered JS, so Jina Reader is only a text fallback when the API path fails.
+# URL: jobs.ashbyhq.com/{org}/{jobPostingId}[/application]
 
 if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
   BASE="${URL%%\?*}"
   BASE="${BASE%/}"
   BASE="${BASE%/application}"
   APPLY_URL="${BASE}/application"
+  ORG=$(sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|' <<<"$BASE")
+  JOB_ID=$(sed -E 's|.*/([A-Za-z0-9-]+)$|\1|' <<<"$BASE")
+
+  GQL=$(jq -n --arg org "$ORG" --arg jid "$JOB_ID" '{
+    operationName: "ApiJobPosting",
+    variables: {organizationHostedJobsPageName: $org, jobPostingId: $jid},
+    query: "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { applicationForm { sections { title fieldEntries { isRequired field } } } } }"
+  }')
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+    -H "Content-Type: application/json" \
+    -H "Origin: https://jobs.ashbyhq.com" \
+    --data-raw "$GQL" \
+    "https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting" 2>/dev/null || true)
+
+  if [[ -n "$RESPONSE" ]] && jq -e '.data.jobPosting.applicationForm.sections' <<<"$RESPONSE" >/dev/null 2>&1; then
+    # field is a JSON scalar carrying {title, type, selectableValues, ...}
+    QUESTIONS=$(jq '
+      [ (.data.jobPosting.applicationForm.sections // [])[]
+        | (.fieldEntries // [])[]
+        | {
+            label: (.field.title // ""),
+            type: (.field.type // "unknown"),
+            required: (.isRequired // null),
+            options: ((.field.selectableValues // [])
+                      | map(.label // .value // tostring)
+                      | if length == 0 then null else . end)
+          } ]
+      | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+    if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+      emit "ashby" "$APPLY_URL" "api" "$QUESTIONS" ""
+      exit 0
+    fi
+  fi
+
+  # API path failed — degrade to Jina Reader text, then to a bare browser handoff.
   MD=$(jina_fetch "$APPLY_URL")
   if [[ -n "$MD" ]]; then
     emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
@@ -253,6 +307,26 @@ if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
     emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
   else
     emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Factorial ────────────────────────────────────────────────────────────────
+# Factorial self-hosts job boards on {company}.factorialhr.com. The apply form is
+# client-rendered with no known public form endpoint, so surface a sensible
+# apply_url plus the job-page text and hand the form off to a browser.
+# URL: {company}.factorialhr.com/job_posting/{slug}  (or /jobs/...)
+
+if grep -qE 'factorialhr\.com' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  APPLY_URL="$BASE"
+  HTML=$(fetch "$URL")
+  if [[ -n "$HTML" ]]; then
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  else
+    MD=$(jina_fetch "$URL")
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
   fi
   exit 0
 fi

--- a/.agents/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.agents/skills/generate-application/scripts/fetch-application-form.sh
@@ -14,7 +14,7 @@
 #   {
 #     "url": "...",          input job posting URL
 #     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
-#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
@@ -30,7 +30,7 @@
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
 # empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -286,8 +286,8 @@ fi
 # No apply link found — return the job page text so the agent can look for
 # embedded questions, and signal that a browser is needed for the form.
 if [[ -n "$HTML" ]]; then
-  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  emit "generic" "$URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
 else
   MD=$(jina_fetch "$URL")
-  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+  emit "generic" "$URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
 fi

--- a/.agents/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.agents/skills/generate-application/scripts/fetch-application-form.sh
@@ -63,7 +63,7 @@ jina_fetch() {
 }
 
 strip_html() {
-  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+  perl -0777 -pe 's{<script\b[^>]*>.*?</script>}{}gis; s{<style\b[^>]*>.*?</style>}{}gis; s{<[^>]*>}{ }g' \
     | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
     | sed -E 's/[[:space:]]+/ /g' \
     | sed '/^[[:space:]]*$/d'

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -20,7 +20,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Script | Purpose |
 |--------|---------|
 | `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Jina Reader → plain curl. |
-| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, questions, form_text}` JSON. Structured questions via Greenhouse/Workable public APIs; apply-page scraping for Lever/generic; Jina for JS-rendered Ashby forms. |
+| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON. Structured questions via Greenhouse/Workable/Ashby public APIs; apply-page scraping for Lever/generic. When `needs_browser: true` the form wasn't captured — open `apply_url` with browser tools. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Claude in `bypassPermissions` mode and sends a push notification when done. |
 
 ## Search Budget (Hard Limits)
@@ -324,9 +324,8 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
    ```bash
    bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "$JOB_URL"
    ```
-   - `questions` non-empty → use them as the authoritative form
-   - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
-   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - `needs_browser: false` and `questions` non-empty → use them as the authoritative form
+   - `needs_browser: true` → the form wasn't captured; open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form (if browser tools are unavailable, extract questions from `form_text`, then try `WebFetch` on `apply_url`)
    - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
 3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
 4. Automatically invoke `find-linkedin-contacts` for this company+role

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -20,6 +20,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Script | Purpose |
 |--------|---------|
 | `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Jina Reader → plain curl. |
+| `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, questions, form_text}` JSON. Structured questions via Greenhouse/Workable public APIs; apply-page scraping for Lever/generic; Jina for JS-rendered Ashby forms. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Claude in `bypassPermissions` mode and sends a push notification when done. |
 
 ## Search Budget (Hard Limits)
@@ -55,6 +56,8 @@ When parsing a posting with Jina Reader, always look for: `Posted`, `Date posted
 | Fetch career pages (JS-heavy) | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` |
 | Search LinkedIn Jobs (authenticated) | `mcp__claude-in-chrome__*` browser tools |
 | Parse job posting content | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
+| Fetch application form + questions | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` |
+| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `get_page_text` on the `apply_url` |
 | Fallback fetch | `WebFetch` |
 
 **URL Caching with qurl — check before every fetch:**
@@ -277,17 +280,20 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 1. Fetch the full posting: `bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` — returns `{url, posted_date, status, content}` JSON
 2. **Freshness check:** extract the posted date from the parsed content. If the role is closed or older than 5 months, **stop and report** — do not score. If date is unknown, note it and proceed with a warning.
-3. Score with dimension breakdown
-4. Determine positioning frame
-5. Map every requirement to a proof point
-6. Identify gaps honestly
-7. Check for hidden fit signals
-8. Recommend GO / STRETCH / PASS
+3. Fetch the application form: `bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` — capture the `apply_url` and how many custom questions the form carries (this feeds the effort estimate and the Application Package)
+4. Score with dimension breakdown
+5. Determine positioning frame
+6. Map every requirement to a proof point
+7. Identify gaps honestly
+8. Check for hidden fit signals
+9. Recommend GO / STRETCH / PASS
 
 ```
 ## Deep Analysis: [Role] at [Company]
 
 **Job URL**: [link]
+**Apply URL**: [apply deep link or "not found — check manually"]
+**Application Form**: [N custom questions / standard fields only / unreadable (JS or login wall)]
 **Posted Date**: [date or "unknown"]
 **Status**: Open / Closed / Unknown
 **Overall Score**: XX%
@@ -311,9 +317,30 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 ## Mode 4: Application Package
 
+**A job ad is not the application.** The real form — screening questions, essay prompts, salary/visa/notice fields, required attachments — lives on the apply deep link. The package is not complete without it.
+
 1. Run Deep Analysis (Mode 3)
-2. If score >= 60%, generate cover letter + resume talking points + approach angle
-3. Automatically invoke `find-linkedin-contacts` for this company+role
+2. If score >= 60%, fetch the application form:
+   ```bash
+   bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "$JOB_URL"
+   ```
+   - `questions` non-empty → use them as the authoritative form
+   - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
+   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
+3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
+4. Automatically invoke `find-linkedin-contacts` for this company+role
+
+### Application Form Answers
+
+For every question found in step 2, include a section in the package:
+
+- **Essay/motivation questions** — full drafted answer per the cover letter rules (concrete metrics, honest, tone matched to culture; respect any stated word/character limit)
+- **Factual questions** (salary expectation, notice period, visa/work authorization, start date) — answer from the profile if present; otherwise insert a `[FILL ME: …]` placeholder and list it in the summary — never guess personal facts
+- **Yes/no screeners** — answer honestly from the profile; if an honest answer is a knockout risk, flag it prominently rather than fudging it
+- **Standard fields** (name, email, CV upload, LinkedIn) — list them so nothing is a surprise at submit time; no draft needed
+
+Record the `apply_url` and the form source (api / apply-page / browser / unreadable) at the top of the section.
 
 ### Cover Letter Structure
 1. Opening hook — the most relevant intersection, not generic interest
@@ -355,3 +382,4 @@ Rules: concrete outcomes only, ~350 words, tone matched to culture.
 - When in doubt about positioning, default to "production AI engineer with deep domain expertise in research infrastructure"
 - All searches should include current year to find active postings
 - If a career page is behind authentication or can't be fetched, note this and suggest the user check manually
+- **The job ad is not the application** — for Deep Analysis and Application Package, always resolve the apply deep link and its form questions via `fetch-application-form.sh`; a package without the form's questions (or an explicit unreadable-form note with the `apply_url`) is incomplete

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -57,7 +57,7 @@ When parsing a posting with Jina Reader, always look for: `Posted`, `Date posted
 | Search LinkedIn Jobs (authenticated) | `mcp__claude-in-chrome__*` browser tools |
 | Parse job posting content | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
 | Fetch application form + questions | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` |
-| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `get_page_text` on the `apply_url` |
+| Read a JS-only or login-walled apply form | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` on the `apply_url` |
 | Fallback fetch | `WebFetch` |
 
 **URL Caching with qurl — check before every fetch:**
@@ -136,14 +136,14 @@ leads/
 
 Budget: max 4 career page fetches + LinkedIn browser search.
 
-1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `get_page_text` to extract roles:
+1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://openai.com/careers/search/`
    - `https://www.anthropic.com/careers/jobs`
    - `https://holtzbrinck.com/en/jobs`
    - On each career page, check for a "posted date" or "last updated" field; skip any role posted more than 5 months ago or marked closed.
 2. Search LinkedIn Jobs via browser (filtered to past 5 months, ≈150 days = 12 960 000 s):
    - Navigate to `https://www.linkedin.com/jobs/search/?keywords=AI+Engineer+research+infrastructure&location=Europe&f_TPR=r12960000`
-   - Use `get_page_text` to extract job titles, companies, URLs, **and posted dates**
+   - Use `mcp__claude-in-chrome__get_page_text` to extract job titles, companies, URLs, **and posted dates**
    - Run 1–2 additional LinkedIn searches varying keywords (Staff Engineer LLM, Head of AI open science) using the same `f_TPR=r12960000` filter
    - Discard any result where LinkedIn shows "Closed" or a posted date older than 5 months
 3. Return: list of `{title, company, url, posted_date}` objects — include `posted_date` whenever visible
@@ -267,7 +267,7 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 ## Mode 2: Company Search
 
 1. Search `[company] careers engineering 2026` and `[company] jobs AI ML 2026`
-2. Fetch career page via browser (`mcp__claude-in-chrome__navigate` + `get_page_text`) or Jina Reader as fallback
+2. Fetch career page via browser (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) or Jina Reader as fallback
 3. **Apply freshness filter:** discard any role marked closed/filled or with a posted date older than 5 months. Flag roles with no visible date as `posted_date: unknown`.
 4. List only open, recent roles in a table with `URL` and `Posted` columns (clickable markdown links)
 5. Score each using the multi-dimensional matrix
@@ -326,7 +326,7 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
    ```
    - `questions` non-empty → use them as the authoritative form
    - `questions` empty but `form_text` present → extract the questions from `form_text` yourself
-   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
+   - `source: "none"` (JS-only or login wall) → open `apply_url` with `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` and read the rendered form; if browser tools are unavailable, try `WebFetch` on `apply_url`
    - Still unreadable → include the `apply_url` in the package with an explicit "check the form manually before submitting" note — never silently skip it
 3. Generate cover letter + resume talking points + approach angle + **application form answers** (see below)
 4. Automatically invoke `find-linkedin-contacts` for this company+role

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# fetch-application-form.sh — Discover a job posting's application form deep link
+# and extract the questions a candidate must answer to submit a FULL application.
+#
+# A job ad is not the application. Most ATSs put the real form (screening
+# questions, essay prompts, salary/visa/notice fields, required attachments)
+# on a separate apply URL. This script finds that deep link and pulls the
+# questions, structured where the ATS exposes them publicly.
+#
+# Usage:
+#   ./scripts/fetch-application-form.sh <job-url>
+#
+# Output: JSON to stdout
+#   {
+#     "url": "...",          input job posting URL
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "source": "api|apply-page|none",
+#     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
+#     "form_text": "..."     raw apply-page text when questions could not be fully structured
+#   }
+#
+# Strategy per ATS:
+#   greenhouse       → public boards API with ?questions=true (full structured form)
+#   workable         → public form API (v3, then v1)
+#   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
+#   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
+#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   generic          → scan job page HTML for an apply link, fetch it, extract labels
+#
+# The script never fails hard: each strategy degrades to the next, ending with an
+# empty questions list and source "none" so the calling agent knows to open
+# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+#
+# Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
+
+set -uo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo '{"error": "Usage: fetch-application-form.sh <job-url>"}' >&2
+  exit 1
+fi
+
+JINA_KEY="${JINA_API_KEY:-}"
+TIMEOUT=25
+UA="Mozilla/5.0 (compatible; job-application-fetch/1.0)"
+MAX_TEXT=20000
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+fetch() {
+  curl -sfL --max-time "$TIMEOUT" -A "$UA" "$@" 2>/dev/null || true
+}
+
+jina_fetch() {
+  local target="$1"
+  [[ -z "$JINA_KEY" ]] && return 0
+  curl -sf --max-time 45 \
+    -H "Authorization: Bearer ${JINA_KEY}" \
+    -H "X-Return-Format: markdown" \
+    "https://r.jina.ai/${target}" 2>/dev/null || true
+}
+
+strip_html() {
+  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+    | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
+    | sed -E 's/[[:space:]]+/ /g' \
+    | sed '/^[[:space:]]*$/d'
+}
+
+# stdin: raw HTML → candidate form-field labels, one per line
+extract_labels_from_html() {
+  {
+    grep -oE '<label[^>]*>[^<]{3,200}' | sed -E 's/<label[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE '<legend[^>]*>[^<]{3,200}' | sed -E 's/<legend[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE 'aria-label="[^"]{3,200}"' | sed -E 's/^aria-label="//; s/"$//'
+  } <<<"$1" || true
+  {
+    grep -oE 'placeholder="[^"]{3,200}"' | sed -E 's/^placeholder="//; s/"$//'
+  } <<<"$1" || true
+}
+
+# stdin: one label per line → JSON array of question objects
+labels_to_questions_json() {
+  sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g' \
+    | jq -R -s '
+        split("\n")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 2 and length < 300))
+        | unique
+        | map({label: ., type: "unknown", required: null, options: null})' 2>/dev/null \
+    || echo "[]"
+}
+
+emit() {
+  local ats="$1" apply_url="$2" source="$3" questions="$4" form_text="$5"
+  [[ -z "$questions" ]] && questions="[]"
+  jq -n \
+    --arg url "$URL" \
+    --arg ats "$ats" \
+    --arg apply_url "$apply_url" \
+    --arg source "$source" \
+    --argjson questions "$questions" \
+    --arg form_text "$form_text" \
+    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+}
+
+# fetch an apply page and emit best-effort results for a known ATS
+emit_from_apply_page() {
+  local ats="$1" apply_url="$2"
+  local html md
+  html=$(fetch "$apply_url")
+  if [[ -n "$html" ]]; then
+    local labels questions text
+    labels=$(extract_labels_from_html "$html")
+    questions=$(labels_to_questions_json <<<"$labels")
+    text=$(strip_html <<<"$html" | head -c "$MAX_TEXT")
+    emit "$ats" "$apply_url" "apply-page" "$questions" "$text"
+    return 0
+  fi
+  md=$(jina_fetch "$apply_url")
+  if [[ -n "$md" ]]; then
+    emit "$ats" "$apply_url" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$md")"
+    return 0
+  fi
+  emit "$ats" "$apply_url" "none" "[]" ""
+}
+
+# ── Greenhouse ────────────────────────────────────────────────────────────────
+# Public boards API returns the FULL application form via ?questions=true:
+# labels, required flags, field types, and dropdown options — no auth needed.
+# URL patterns: (job-)boards.greenhouse.io/{board}/jobs/{id}, incl. eu. hosts.
+
+if grep -qE 'greenhouse\.io/[^/]+/jobs/[0-9]+' <<<"$URL"; then
+  BOARD=$(grep -oE 'greenhouse\.io/([^/]+)/jobs' <<<"$URL" | cut -d'/' -f2)
+  JOB_ID=$(grep -oE '/jobs/[0-9]+' <<<"$URL" | grep -oE '[0-9]+')
+
+  HOSTS="boards-api.greenhouse.io api.greenhouse.io"
+  grep -q 'eu\.greenhouse\.io' <<<"$URL" && HOSTS="boards-api.eu.greenhouse.io $HOSTS"
+
+  for HOST in $HOSTS; do
+    RESPONSE=$(fetch "https://${HOST}/v1/boards/${BOARD}/jobs/${JOB_ID}?questions=true")
+    if [[ -n "$RESPONSE" ]] && jq -e '.id' <<<"$RESPONSE" >/dev/null 2>&1; then
+      APPLY_URL=$(jq -r '.absolute_url // ""' <<<"$RESPONSE")
+      [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+      APPLY_URL="${APPLY_URL}#app"
+      QUESTIONS=$(jq '
+        [ (.questions // [])[],
+          ((.compliance // [])[] | (.questions // [])[]),
+          ((.demographic_questions.questions // [])[]) ]
+        | map({
+            label: (.label // ""),
+            type: (.fields[0].type // .type // "unknown"),
+            required: (.required // null),
+            options: ((.fields[0].values // .answer_options // [])
+                      | map(.label // .name // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      emit "greenhouse" "$APPLY_URL" "api" "${QUESTIONS:-[]}" ""
+      exit 0
+    fi
+  done
+
+  # API unreachable — fall back to reading the posting page itself
+  emit_from_apply_page "greenhouse" "${URL}#app"
+  exit 0
+fi
+
+# ── Workable ─────────────────────────────────────────────────────────────────
+# apply.workable.com exposes the application form definition as JSON.
+# URL pattern: apply.workable.com/{account}/j/{SHORTCODE}
+
+if grep -qE 'apply\.workable\.com/[^/]+/j/[A-Za-z0-9]+' <<<"$URL"; then
+  ACCOUNT=$(sed -E 's|.*apply\.workable\.com/([^/]+)/j/.*|\1|' <<<"$URL")
+  SHORTCODE=$(sed -E 's|.*/j/([A-Za-z0-9]+).*|\1|' <<<"$URL")
+  APPLY_URL="https://apply.workable.com/${ACCOUNT}/j/${SHORTCODE}/apply/"
+
+  for V in v3 v1; do
+    RESPONSE=$(fetch "https://apply.workable.com/api/${V}/accounts/${ACCOUNT}/jobs/${SHORTCODE}/form")
+    if [[ -n "$RESPONSE" ]] && jq -e 'type == "object"' <<<"$RESPONSE" >/dev/null 2>&1; then
+      QUESTIONS=$(jq '
+        [ ((.fields // [])[]), ((.questions // [])[]) ]
+        | map({
+            label: (.label // .body // .key // ""),
+            type: (.type // "unknown"),
+            required: (.required // null),
+            options: ((.options // .choices // [])
+                      | map(.body // .value // .label // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+        emit "workable" "$APPLY_URL" "api" "$QUESTIONS" ""
+        exit 0
+      fi
+    fi
+  done
+
+  emit_from_apply_page "workable" "$APPLY_URL"
+  exit 0
+fi
+
+# ── Lever ────────────────────────────────────────────────────────────────────
+# The apply form lives at {posting-url}/apply and is server-rendered, so custom
+# questions appear directly in the HTML. URL: jobs.(eu.)lever.co/{company}/{uuid}
+
+if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/apply}"
+  emit_from_apply_page "lever" "${BASE}/apply"
+  exit 0
+fi
+
+# ── Ashby ────────────────────────────────────────────────────────────────────
+# Apply form at {posting-url}/application; the page is client-rendered, so only
+# Jina Reader (which executes JS) can read it non-interactively.
+
+if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/application}"
+  APPLY_URL="${BASE}/application"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "ashby" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── SmartRecruiters ──────────────────────────────────────────────────────────
+# Public postings API gives the canonical applyUrl; the form itself is JS-heavy.
+
+if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
+  COMPANY=$(sed -E 's|.*jobs\.smartrecruiters\.com/([^/]+).*|\1|' <<<"$URL")
+  POSTING_ID=$(grep -oE '/[0-9]{9,}' <<<"$URL" | grep -oE '[0-9]+' | head -1 || true)
+  APPLY_URL=""
+  if [[ -n "${POSTING_ID:-}" ]]; then
+    RESPONSE=$(fetch "https://api.smartrecruiters.com/v1/companies/${COMPANY}/postings/${POSTING_ID}")
+    APPLY_URL=$(jq -r '.applyUrl // ""' <<<"$RESPONSE" 2>/dev/null || true)
+  fi
+  [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Generic ──────────────────────────────────────────────────────────────────
+# Fetch the job page, look for an apply/application link, follow it, and
+# extract whatever field labels are visible.
+
+HTML=$(fetch "$URL")
+APPLY_URL=""
+if [[ -n "$HTML" ]]; then
+  CAND=$(grep -oiE 'href="[^"]*(apply|application)[^"]*"' <<<"$HTML" \
+    | sed -E 's/^[Hh][Rr][Ee][Ff]="//; s/"$//' \
+    | grep -viE '\.(css|js|png|jpg|svg)([?#]|$)' \
+    | head -1 || true)
+  if [[ -n "${CAND:-}" ]]; then
+    case "$CAND" in
+      http*)  APPLY_URL="$CAND" ;;
+      //*)    APPLY_URL="https:${CAND}" ;;
+      /*)     ORIGIN=$(sed -E 's|^(https?://[^/]+).*|\1|' <<<"$URL"); APPLY_URL="${ORIGIN}${CAND}" ;;
+      *)      APPLY_URL="${URL%/}/${CAND}" ;;
+    esac
+  fi
+fi
+
+if [[ -n "$APPLY_URL" ]]; then
+  emit_from_apply_page "generic" "$APPLY_URL"
+  exit 0
+fi
+
+# No apply link found — return the job page text so the agent can look for
+# embedded questions, and signal that a browser is needed for the form.
+if [[ -n "$HTML" ]]; then
+  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+else
+  MD=$(jina_fetch "$URL")
+  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+fi

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -13,24 +13,32 @@
 # Output: JSON to stdout
 #   {
 #     "url": "...",          input job posting URL
-#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|factorial|generic",
 #     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
+#     "needs_browser": true|false,  true when the form wasn't captured (source apply-page/none AND questions empty)
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
 #   }
+#
+# needs_browser is the handoff signal: when true, the returned questions are empty
+# and form_text is at best a thin JD blob, so the calling agent MUST open apply_url
+# with browser tools (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text)
+# to read the real form instead of trusting this output. When false, questions[] is
+# authoritative and no browser step is needed.
 #
 # Strategy per ATS:
 #   greenhouse       → public boards API with ?questions=true (full structured form)
 #   workable         → public form API (v3, then v1)
 #   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
 #   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
-#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   ashby            → public GraphQL posting API (full structured form); Jina Reader fallback
+#   factorial        → detect factorialhr.com, surface apply_url, hand off to browser
 #   generic          → scan job page HTML for an apply link, fetch it, extract labels
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
-# empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
+# empty questions list, source "none", and needs_browser true so the calling agent
+# knows to open apply_url in a browser instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -107,7 +115,15 @@ emit() {
     --arg source "$source" \
     --argjson questions "$questions" \
     --arg form_text "$form_text" \
-    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+    '{
+       url: $url,
+       ats: $ats,
+       apply_url: $apply_url,
+       source: $source,
+       needs_browser: (($source == "apply-page" or $source == "none") and ($questions | length) == 0),
+       questions: $questions,
+       form_text: $form_text
+     }'
 }
 
 # fetch an apply page and emit best-effort results for a known ATS
@@ -219,14 +235,52 @@ if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
 fi
 
 # ── Ashby ────────────────────────────────────────────────────────────────────
-# Apply form at {posting-url}/application; the page is client-rendered, so only
-# Jina Reader (which executes JS) can read it non-interactively.
+# Ashby exposes a public GraphQL endpoint (non-user-graphql, ApiJobPosting) that
+# returns the FULL application form — sections → fieldEntries → field — structured
+# and unauthenticated, just like Greenhouse. The apply page itself is client-
+# rendered JS, so Jina Reader is only a text fallback when the API path fails.
+# URL: jobs.ashbyhq.com/{org}/{jobPostingId}[/application]
 
 if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
   BASE="${URL%%\?*}"
   BASE="${BASE%/}"
   BASE="${BASE%/application}"
   APPLY_URL="${BASE}/application"
+  ORG=$(sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|' <<<"$BASE")
+  JOB_ID=$(sed -E 's|.*/([A-Za-z0-9-]+)$|\1|' <<<"$BASE")
+
+  GQL=$(jq -n --arg org "$ORG" --arg jid "$JOB_ID" '{
+    operationName: "ApiJobPosting",
+    variables: {organizationHostedJobsPageName: $org, jobPostingId: $jid},
+    query: "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { applicationForm { sections { title fieldEntries { isRequired field } } } } }"
+  }')
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+    -H "Content-Type: application/json" \
+    -H "Origin: https://jobs.ashbyhq.com" \
+    --data-raw "$GQL" \
+    "https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting" 2>/dev/null || true)
+
+  if [[ -n "$RESPONSE" ]] && jq -e '.data.jobPosting.applicationForm.sections' <<<"$RESPONSE" >/dev/null 2>&1; then
+    # field is a JSON scalar carrying {title, type, selectableValues, ...}
+    QUESTIONS=$(jq '
+      [ (.data.jobPosting.applicationForm.sections // [])[]
+        | (.fieldEntries // [])[]
+        | {
+            label: (.field.title // ""),
+            type: (.field.type // "unknown"),
+            required: (.isRequired // null),
+            options: ((.field.selectableValues // [])
+                      | map(.label // .value // tostring)
+                      | if length == 0 then null else . end)
+          } ]
+      | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+    if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+      emit "ashby" "$APPLY_URL" "api" "$QUESTIONS" ""
+      exit 0
+    fi
+  fi
+
+  # API path failed — degrade to Jina Reader text, then to a bare browser handoff.
   MD=$(jina_fetch "$APPLY_URL")
   if [[ -n "$MD" ]]; then
     emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
@@ -253,6 +307,26 @@ if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
     emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
   else
     emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Factorial ────────────────────────────────────────────────────────────────
+# Factorial self-hosts job boards on {company}.factorialhr.com. The apply form is
+# client-rendered with no known public form endpoint, so surface a sensible
+# apply_url plus the job-page text and hand the form off to a browser.
+# URL: {company}.factorialhr.com/job_posting/{slug}  (or /jobs/...)
+
+if grep -qE 'factorialhr\.com' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  APPLY_URL="$BASE"
+  HTML=$(fetch "$URL")
+  if [[ -n "$HTML" ]]; then
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  else
+    MD=$(jina_fetch "$URL")
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
   fi
   exit 0
 fi

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -14,7 +14,7 @@
 #   {
 #     "url": "...",          input job posting URL
 #     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
-#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
@@ -30,7 +30,7 @@
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
 # empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -286,8 +286,8 @@ fi
 # No apply link found — return the job page text so the agent can look for
 # embedded questions, and signal that a browser is needed for the form.
 if [[ -n "$HTML" ]]; then
-  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  emit "generic" "$URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
 else
   MD=$(jina_fetch "$URL")
-  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+  emit "generic" "$URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
 fi

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh
@@ -63,7 +63,7 @@ jina_fetch() {
 }
 
 strip_html() {
-  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+  perl -0777 -pe 's{<script\b[^>]*>.*?</script>}{}gis; s{<style\b[^>]*>.*?</style>}{}gis; s{<[^>]*>}{ }g' \
     | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
     | sed -E 's/[[:space:]]+/ /g' \
     | sed '/^[[:space:]]*$/d'

--- a/.claude/skills/generate-application/SKILL.md
+++ b/.claude/skills/generate-application/SKILL.md
@@ -42,7 +42,7 @@ Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script 
 Interpret the result:
 - **`questions` non-empty** — use them directly; they are the authoritative form.
 - **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
-- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `get_page_text`), open `apply_url` and read the rendered form.
+- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`), open `apply_url` and read the rendered form.
 - **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
 
 Classify each question into three buckets (used in Step 9):

--- a/.claude/skills/generate-application/SKILL.md
+++ b/.claude/skills/generate-application/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: generate-application
-description: This skill should be used when the user says "apply for [job URL]", "generate application for", "prepare my CV for", "create application package for", "write a cover letter for", or provides a job posting URL and wants to apply. Generates a full application package — targeted CV data file, analysis, and cover letter — saved under applications/[company]-[role]/ in the project root.
-version: 0.1.0
+description: This skill should be used when the user says "apply for [job URL]", "generate application for", "prepare my CV for", "create application package for", "write a cover letter for", or provides a job posting URL and wants to apply. Generates a full application package — targeted CV data file, analysis, application form answers, and cover letter — saved under applications/[company]-[role]/ in the project root.
+version: 0.2.0
 argument-hint: "[job-url]"
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent", "WebFetch"]
 ---
 
 # generate-application
 
-Generate a complete, targeted application package for a job posting. The output lives at `applications/YYYY-MM-DD-[company]-[role-slug]/` in the project root and includes a deep analysis, a targeted CV data file, and a two-paragraph cover letter.
+Generate a complete, targeted application package for a job posting. The output lives at `applications/YYYY-MM-DD-[company]-[role-slug]/` in the project root and includes a deep analysis, a targeted CV data file, drafted answers to the actual application form questions, and a two-paragraph cover letter.
+
+**A job ad is not the application.** The real application lives on a separate apply deep link (Greenhouse `#app` form, Lever `/apply`, Ashby `/application`, Workable apply page, …) with screening questions, essay prompts, and factual fields the ad never mentions. A package that skips these is incomplete — Step 2 is mandatory, not optional.
 
 ## Step 1 — Fetch and Parse the Job Posting
 
@@ -27,22 +29,43 @@ Extract from the posting:
 - Work arrangement (remote, hybrid, location)
 - Mission/culture signals
 
-## Step 2 — Read Kristian's Profile
+## Step 2 — Fetch the Application Form (Deep Link) and Extract Questions
+
+Discover the apply deep link and pull the actual application questions:
+
+```bash
+bash .claude/skills/generate-application/scripts/fetch-application-form.sh "[job-url]"
+```
+
+Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API — both return labels, required flags, and dropdown options) and falls back to scraping the apply page.
+
+Interpret the result:
+- **`questions` non-empty** — use them directly; they are the authoritative form.
+- **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
+- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `get_page_text`), open `apply_url` and read the rendered form.
+- **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
+
+Classify each question into three buckets (used in Step 9):
+1. **Essay/motivation questions** ("Why do you want to work here?", "Describe a project…") — these need drafted answers.
+2. **Factual questions** (salary expectation, notice period, visa/work authorization, start date, location, years of experience) — answer from the profile where possible.
+3. **Standard fields** (name, email, phone, CV/resume upload, LinkedIn URL) — list them so nothing is a surprise, but no draft needed.
+
+## Step 3 — Read Kristian's Profile
 
 Read the full candidate profile before scoring:
 
 ```
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/kristian-profile.md
+.claude/skills/generate-application/references/kristian-profile.md
 ```
 
 Also read the scoring matrix and tone/voice reference:
 
 ```
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/scoring-matrix.md
-$CLAUDE_PLUGIN_ROOT/skills/generate-application/references/tone-and-voice.md
+.claude/skills/generate-application/references/scoring-matrix.md
+.claude/skills/generate-application/references/tone-and-voice.md
 ```
 
-## Step 3 — Score and Analyze
+## Step 4 — Score and Analyze
 
 Apply the multi-dimensional scoring matrix (see `references/scoring-matrix.md`).
 
@@ -56,7 +79,7 @@ Produce for `analysis.md`:
 
 If score < 60% (PASS), tell the user and stop — do not generate a cover letter or CV data for a role with poor fit.
 
-## Step 4 — Determine Output Slug
+## Step 5 — Determine Output Slug
 
 Derive folder name:
 - `company`: lowercase, no spaces, no punctuation (e.g. `iris`, `deepmind`)
@@ -66,15 +89,15 @@ Derive folder name:
 
 The `applications/` directory lives in the project root. Create it (and the slug subfolder) if it doesn't exist.
 
-## Step 5 — Save job-posting.md
+## Step 6 — Save job-posting.md
 
-Write the raw parsed job description to `applications/[slug]/job-posting.md`.
+Write the raw parsed job description to `applications/[slug]/job-posting.md`. Include the `apply_url` from Step 2 at the top.
 
-## Step 6 — Save analysis.md
+## Step 7 — Save analysis.md
 
-Write the full analysis (Step 3 output) to `applications/[slug]/analysis.md`.
+Write the full analysis (Step 4 output) to `applications/[slug]/analysis.md`.
 
-## Step 7 — Generate cv-data.js
+## Step 8 — Generate cv-data.js
 
 Generate a targeted CV data file for this role. This is a CommonJS module that exports an object matching the schema in `src/_data/cvIris.js` (the canonical example of a targeted CV variant — use this as the schema reference, not `src/_data/cv.js`).
 
@@ -82,7 +105,7 @@ Apply tone and voice guidance from `references/tone-and-voice.md` when writing t
 
 Reframe employment bullets, profile statement, and skill rankings to match:
 - The role's tech stack (prioritise skills they listed first)
-- The positioning frame chosen in Step 3
+- The positioning frame chosen in Step 4
 - Concrete proof points with metrics from `references/kristian-profile.md`
 - Honest language — do not invent technologies or claim expertise not in the profile
 
@@ -92,27 +115,59 @@ Also print instructions for the user to integrate it:
 1. Copy `cv-data.js` → `src/_data/cv[Company].js` (camelCase, e.g. `cvDeepMind.js`, `cvCrossref.js`)
 2. Rebuild: `bun run build`
 
-## Step 8 — Generate Cover Letter via Agent
+## Step 9 — Draft application-questions.md
+
+Write `applications/[slug]/application-questions.md` covering **every** question found in Step 2, grouped by bucket:
+
+```markdown
+# Application Form: [Role] at [Company]
+
+**Apply URL**: [apply_url]
+**Form source**: api / apply-page / manual (browser) / unreadable
+
+## Essay & Motivation Questions
+### Q: [question text] (required, max N words if stated)
+[Drafted answer — tone-and-voice rules, concrete proof points with metrics,
+respect any stated word/character limit, honest.]
+
+## Factual Questions
+| Question | Answer |
+|----------|--------|
+| [e.g. Notice period] | [from profile, or `[FILL ME: notice period]`] |
+
+## Standard Fields (no draft needed)
+- Name, email, CV upload, ...
+```
+
+Rules:
+- Draft essay answers with the same voice rules as the cover letter (`references/tone-and-voice.md`) — no em dashes, no invented experience.
+- For yes/no screeners, answer honestly from the profile. If an honest answer is a knockout risk (e.g. "Do you have X?" and the profile says no), flag it prominently rather than fudging it.
+- For personal facts not in the profile (salary expectation, notice period, visa status, earliest start date), insert a `[FILL ME: …]` placeholder — never guess.
+- If the form could not be read at all, this file must still exist, containing the `apply_url` and a note telling the user to check the form manually before submitting.
+
+## Step 10 — Generate Cover Letter via Agent
 
 Dispatch the `cover-letter-writer` agent with:
 - The job posting content
 - The analysis (positioning frame, top 3 proof points, gaps)
 - The company name and role title
+- Any essay questions from Step 2 that overlap with cover letter territory (so the letter and the form answers complement rather than repeat each other)
 
 The agent returns a greeting line, a two-paragraph cover letter body in a warm, helpful, audience-first tone, and a concise close line (for example, "Sincerely,"). It avoids em dashes in output and does not force a first-90-days commitment. Save to `applications/[slug]/cover-letter.md`.
 
 Invoke using the Agent tool with subagent_type matching the `cover-letter-writer` agent. Pass all context in the prompt.
 
-## Step 9 — Write README.md
+## Step 11 — Write README.md
 
-Write `applications/[slug]/README.md` using the template in `references/output-structure.md`. Status should be `Draft` by default.
+Write `applications/[slug]/README.md` using the template in `references/output-structure.md`. Status should be `Draft` by default. Include the `apply_url` and list any `[FILL ME]` placeholders still open.
 
-## Step 10 — Present Summary
+## Step 12 — Present Summary
 
 Tell the user:
 - Score and recommendation
 - Folder path where files were saved
 - Which files were generated
+- The apply deep link, how many form questions were found, and any `[FILL ME]` placeholders that need their input before submitting
 - How to integrate `cv-data.js` into the site
 - One-line suggested email subject line for the application
 
@@ -123,9 +178,14 @@ Tell the user:
 - **`references/output-structure.md`** — Folder layout, file formats, and integration steps
 - **`references/tone-and-voice.md`** — Voice rules for cover letter, CV profile, and employment bullets
 
+## Scripts
+
+- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, and generic career pages.
+
 ## Notes
 
 - Always read the full posting before scoring — do not assume from job title alone
 - Be honest about gaps — authenticity over overselling
 - The cover letter body must be exactly 2 paragraphs. The agent enforces this.
+- The package is not complete without `application-questions.md` — either with the form's questions answered, or with an explicit note that the form is behind a login/JS wall and must be checked manually
 - If the job URL redirects or is behind a wall, ask the user to paste the posting text directly

--- a/.claude/skills/generate-application/SKILL.md
+++ b/.claude/skills/generate-application/SKILL.md
@@ -37,12 +37,11 @@ Discover the apply deep link and pull the actual application questions:
 bash .claude/skills/generate-application/scripts/fetch-application-form.sh "[job-url]"
 ```
 
-Returns JSON: `{url, ats, apply_url, source, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API — both return labels, required flags, and dropdown options) and falls back to scraping the apply page.
+Returns JSON: `{url, ats, apply_url, source, needs_browser, questions, form_text}`. The script uses the ATS's public API where one exists (Greenhouse `?questions=true`, Workable form API, Ashby GraphQL posting API — all return labels, required flags, and dropdown options) and falls back to scraping the apply page.
 
 Interpret the result:
-- **`questions` non-empty** — use them directly; they are the authoritative form.
-- **`questions` empty but `form_text` has content** — read `form_text` and extract every question/field the form asks for yourself.
-- **Both empty** (`source: "none"` — JS-only page or login wall) — fetch `apply_url` with `WebFetch`; if browser tools are available (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`), open `apply_url` and read the rendered form.
+- **`needs_browser: false`** — `questions` is authoritative; use it directly.
+- **`needs_browser: true`** — the form wasn't captured (empty `questions`; `form_text` is at best a thin JD blob). Open `apply_url` with browser tools (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) and read the rendered form. If browser tools are unavailable, extract whatever you can from `form_text`, then try `WebFetch` on `apply_url`.
 - **Still unreadable** — record this explicitly in `application-questions.md` with the `apply_url` so the user can open it manually. Never silently skip the form.
 
 Classify each question into three buckets (used in Step 9):
@@ -180,7 +179,7 @@ Tell the user:
 
 ## Scripts
 
-- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, and generic career pages.
+- **`scripts/fetch-application-form.sh <job-url>`** — Discover the apply deep link and extract application form questions (`{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON). Handles Greenhouse, Lever, Ashby, Workable, SmartRecruiters, Factorial, and generic career pages. `needs_browser: true` signals the form must be read with browser tools.
 
 ## Notes
 

--- a/.claude/skills/generate-application/references/output-structure.md
+++ b/.claude/skills/generate-application/references/output-structure.md
@@ -7,12 +7,23 @@ Each application generates a folder at `applications/YYYY-MM-DD-[company]-[role-
 ```
 applications/
   YYYY-MM-DD-[company]-[role-slug]/
-    README.md           ← One-line summary: company, role, score, status
-    job-posting.md      ← Raw parsed job description (from Jina)
-    analysis.md         ← Deep analysis: score breakdown, gap mapping, positioning
-    cover-letter.md     ← Final cover letter (greeting + 2 body paragraphs + concise close)
-    cv-data.js          ← CV data file ready to drop into src/_data/
+    README.md                 ← One-line summary: company, role, score, status, apply URL
+    job-posting.md            ← Raw parsed job description (from Jina), apply URL at top
+    analysis.md               ← Deep analysis: score breakdown, gap mapping, positioning
+    application-questions.md  ← Every question from the actual apply form, with drafted answers
+    cover-letter.md           ← Final cover letter (greeting + 2 body paragraphs + concise close)
+    cv-data.js                ← CV data file ready to drop into src/_data/
 ```
+
+## application-questions.md
+
+Sourced from the apply deep link (Greenhouse `#app`, Lever `/apply`, Ashby `/application`, Workable apply page), not the job ad. Three sections:
+
+1. **Essay & Motivation Questions** — full drafted answers, tone-and-voice compliant
+2. **Factual Questions** — table of question → answer; unknowns marked `[FILL ME: …]`
+3. **Standard Fields** — plain list (name, email, CV upload, …), no drafts
+
+If the form was unreadable (login/JS wall), the file still exists with the apply URL and a manual-check note.
 
 ## cv-data.js
 
@@ -40,6 +51,9 @@ The site will pick up the new CV data automatically.
 | Company | [Company] |
 | Role | [Role Title] |
 | URL | [Job URL] |
+| Apply URL | [apply deep link from fetch-application-form.sh] |
+| Form questions | [N found / unreadable — check manually] |
+| Open placeholders | [list of `[FILL ME]` items, or "none"] |
 | Date | [YYYY-MM-DD] |
 | Score | [XX]% |
 | Status | Applied / Draft / Rejected / Interview |

--- a/.claude/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.claude/skills/generate-application/scripts/fetch-application-form.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# fetch-application-form.sh — Discover a job posting's application form deep link
+# and extract the questions a candidate must answer to submit a FULL application.
+#
+# A job ad is not the application. Most ATSs put the real form (screening
+# questions, essay prompts, salary/visa/notice fields, required attachments)
+# on a separate apply URL. This script finds that deep link and pulls the
+# questions, structured where the ATS exposes them publicly.
+#
+# Usage:
+#   ./scripts/fetch-application-form.sh <job-url>
+#
+# Output: JSON to stdout
+#   {
+#     "url": "...",          input job posting URL
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "source": "api|apply-page|none",
+#     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
+#     "form_text": "..."     raw apply-page text when questions could not be fully structured
+#   }
+#
+# Strategy per ATS:
+#   greenhouse       → public boards API with ?questions=true (full structured form)
+#   workable         → public form API (v3, then v1)
+#   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
+#   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
+#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   generic          → scan job page HTML for an apply link, fetch it, extract labels
+#
+# The script never fails hard: each strategy degrades to the next, ending with an
+# empty questions list and source "none" so the calling agent knows to open
+# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+#
+# Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
+
+set -uo pipefail
+
+URL="${1:-}"
+if [[ -z "$URL" ]]; then
+  echo '{"error": "Usage: fetch-application-form.sh <job-url>"}' >&2
+  exit 1
+fi
+
+JINA_KEY="${JINA_API_KEY:-}"
+TIMEOUT=25
+UA="Mozilla/5.0 (compatible; job-application-fetch/1.0)"
+MAX_TEXT=20000
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+fetch() {
+  curl -sfL --max-time "$TIMEOUT" -A "$UA" "$@" 2>/dev/null || true
+}
+
+jina_fetch() {
+  local target="$1"
+  [[ -z "$JINA_KEY" ]] && return 0
+  curl -sf --max-time 45 \
+    -H "Authorization: Bearer ${JINA_KEY}" \
+    -H "X-Return-Format: markdown" \
+    "https://r.jina.ai/${target}" 2>/dev/null || true
+}
+
+strip_html() {
+  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+    | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
+    | sed -E 's/[[:space:]]+/ /g' \
+    | sed '/^[[:space:]]*$/d'
+}
+
+# stdin: raw HTML → candidate form-field labels, one per line
+extract_labels_from_html() {
+  {
+    grep -oE '<label[^>]*>[^<]{3,200}' | sed -E 's/<label[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE '<legend[^>]*>[^<]{3,200}' | sed -E 's/<legend[^>]*>//'
+  } <<<"$1" || true
+  {
+    grep -oE 'aria-label="[^"]{3,200}"' | sed -E 's/^aria-label="//; s/"$//'
+  } <<<"$1" || true
+  {
+    grep -oE 'placeholder="[^"]{3,200}"' | sed -E 's/^placeholder="//; s/"$//'
+  } <<<"$1" || true
+}
+
+# stdin: one label per line → JSON array of question objects
+labels_to_questions_json() {
+  sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g' \
+    | jq -R -s '
+        split("\n")
+        | map(gsub("^\\s+|\\s+$"; ""))
+        | map(select(length > 2 and length < 300))
+        | unique
+        | map({label: ., type: "unknown", required: null, options: null})' 2>/dev/null \
+    || echo "[]"
+}
+
+emit() {
+  local ats="$1" apply_url="$2" source="$3" questions="$4" form_text="$5"
+  [[ -z "$questions" ]] && questions="[]"
+  jq -n \
+    --arg url "$URL" \
+    --arg ats "$ats" \
+    --arg apply_url "$apply_url" \
+    --arg source "$source" \
+    --argjson questions "$questions" \
+    --arg form_text "$form_text" \
+    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+}
+
+# fetch an apply page and emit best-effort results for a known ATS
+emit_from_apply_page() {
+  local ats="$1" apply_url="$2"
+  local html md
+  html=$(fetch "$apply_url")
+  if [[ -n "$html" ]]; then
+    local labels questions text
+    labels=$(extract_labels_from_html "$html")
+    questions=$(labels_to_questions_json <<<"$labels")
+    text=$(strip_html <<<"$html" | head -c "$MAX_TEXT")
+    emit "$ats" "$apply_url" "apply-page" "$questions" "$text"
+    return 0
+  fi
+  md=$(jina_fetch "$apply_url")
+  if [[ -n "$md" ]]; then
+    emit "$ats" "$apply_url" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$md")"
+    return 0
+  fi
+  emit "$ats" "$apply_url" "none" "[]" ""
+}
+
+# ── Greenhouse ────────────────────────────────────────────────────────────────
+# Public boards API returns the FULL application form via ?questions=true:
+# labels, required flags, field types, and dropdown options — no auth needed.
+# URL patterns: (job-)boards.greenhouse.io/{board}/jobs/{id}, incl. eu. hosts.
+
+if grep -qE 'greenhouse\.io/[^/]+/jobs/[0-9]+' <<<"$URL"; then
+  BOARD=$(grep -oE 'greenhouse\.io/([^/]+)/jobs' <<<"$URL" | cut -d'/' -f2)
+  JOB_ID=$(grep -oE '/jobs/[0-9]+' <<<"$URL" | grep -oE '[0-9]+')
+
+  HOSTS="boards-api.greenhouse.io api.greenhouse.io"
+  grep -q 'eu\.greenhouse\.io' <<<"$URL" && HOSTS="boards-api.eu.greenhouse.io $HOSTS"
+
+  for HOST in $HOSTS; do
+    RESPONSE=$(fetch "https://${HOST}/v1/boards/${BOARD}/jobs/${JOB_ID}?questions=true")
+    if [[ -n "$RESPONSE" ]] && jq -e '.id' <<<"$RESPONSE" >/dev/null 2>&1; then
+      APPLY_URL=$(jq -r '.absolute_url // ""' <<<"$RESPONSE")
+      [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+      APPLY_URL="${APPLY_URL}#app"
+      QUESTIONS=$(jq '
+        [ (.questions // [])[],
+          ((.compliance // [])[] | (.questions // [])[]),
+          ((.demographic_questions.questions // [])[]) ]
+        | map({
+            label: (.label // ""),
+            type: (.fields[0].type // .type // "unknown"),
+            required: (.required // null),
+            options: ((.fields[0].values // .answer_options // [])
+                      | map(.label // .name // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      emit "greenhouse" "$APPLY_URL" "api" "${QUESTIONS:-[]}" ""
+      exit 0
+    fi
+  done
+
+  # API unreachable — fall back to reading the posting page itself
+  emit_from_apply_page "greenhouse" "${URL}#app"
+  exit 0
+fi
+
+# ── Workable ─────────────────────────────────────────────────────────────────
+# apply.workable.com exposes the application form definition as JSON.
+# URL pattern: apply.workable.com/{account}/j/{SHORTCODE}
+
+if grep -qE 'apply\.workable\.com/[^/]+/j/[A-Za-z0-9]+' <<<"$URL"; then
+  ACCOUNT=$(sed -E 's|.*apply\.workable\.com/([^/]+)/j/.*|\1|' <<<"$URL")
+  SHORTCODE=$(sed -E 's|.*/j/([A-Za-z0-9]+).*|\1|' <<<"$URL")
+  APPLY_URL="https://apply.workable.com/${ACCOUNT}/j/${SHORTCODE}/apply/"
+
+  for V in v3 v1; do
+    RESPONSE=$(fetch "https://apply.workable.com/api/${V}/accounts/${ACCOUNT}/jobs/${SHORTCODE}/form")
+    if [[ -n "$RESPONSE" ]] && jq -e 'type == "object"' <<<"$RESPONSE" >/dev/null 2>&1; then
+      QUESTIONS=$(jq '
+        [ ((.fields // [])[]), ((.questions // [])[]) ]
+        | map({
+            label: (.label // .body // .key // ""),
+            type: (.type // "unknown"),
+            required: (.required // null),
+            options: ((.options // .choices // [])
+                      | map(.body // .value // .label // tostring)
+                      | if length == 0 then null else . end)
+          })
+        | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+      if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+        emit "workable" "$APPLY_URL" "api" "$QUESTIONS" ""
+        exit 0
+      fi
+    fi
+  done
+
+  emit_from_apply_page "workable" "$APPLY_URL"
+  exit 0
+fi
+
+# ── Lever ────────────────────────────────────────────────────────────────────
+# The apply form lives at {posting-url}/apply and is server-rendered, so custom
+# questions appear directly in the HTML. URL: jobs.(eu.)lever.co/{company}/{uuid}
+
+if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/apply}"
+  emit_from_apply_page "lever" "${BASE}/apply"
+  exit 0
+fi
+
+# ── Ashby ────────────────────────────────────────────────────────────────────
+# Apply form at {posting-url}/application; the page is client-rendered, so only
+# Jina Reader (which executes JS) can read it non-interactively.
+
+if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  BASE="${BASE%/application}"
+  APPLY_URL="${BASE}/application"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "ashby" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── SmartRecruiters ──────────────────────────────────────────────────────────
+# Public postings API gives the canonical applyUrl; the form itself is JS-heavy.
+
+if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
+  COMPANY=$(sed -E 's|.*jobs\.smartrecruiters\.com/([^/]+).*|\1|' <<<"$URL")
+  POSTING_ID=$(grep -oE '/[0-9]{9,}' <<<"$URL" | grep -oE '[0-9]+' | head -1 || true)
+  APPLY_URL=""
+  if [[ -n "${POSTING_ID:-}" ]]; then
+    RESPONSE=$(fetch "https://api.smartrecruiters.com/v1/companies/${COMPANY}/postings/${POSTING_ID}")
+    APPLY_URL=$(jq -r '.applyUrl // ""' <<<"$RESPONSE" 2>/dev/null || true)
+  fi
+  [[ -z "$APPLY_URL" ]] && APPLY_URL="$URL"
+  MD=$(jina_fetch "$APPLY_URL")
+  if [[ -n "$MD" ]]; then
+    emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
+  else
+    emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Generic ──────────────────────────────────────────────────────────────────
+# Fetch the job page, look for an apply/application link, follow it, and
+# extract whatever field labels are visible.
+
+HTML=$(fetch "$URL")
+APPLY_URL=""
+if [[ -n "$HTML" ]]; then
+  CAND=$(grep -oiE 'href="[^"]*(apply|application)[^"]*"' <<<"$HTML" \
+    | sed -E 's/^[Hh][Rr][Ee][Ff]="//; s/"$//' \
+    | grep -viE '\.(css|js|png|jpg|svg)([?#]|$)' \
+    | head -1 || true)
+  if [[ -n "${CAND:-}" ]]; then
+    case "$CAND" in
+      http*)  APPLY_URL="$CAND" ;;
+      //*)    APPLY_URL="https:${CAND}" ;;
+      /*)     ORIGIN=$(sed -E 's|^(https?://[^/]+).*|\1|' <<<"$URL"); APPLY_URL="${ORIGIN}${CAND}" ;;
+      *)      APPLY_URL="${URL%/}/${CAND}" ;;
+    esac
+  fi
+fi
+
+if [[ -n "$APPLY_URL" ]]; then
+  emit_from_apply_page "generic" "$APPLY_URL"
+  exit 0
+fi
+
+# No apply link found — return the job page text so the agent can look for
+# embedded questions, and signal that a browser is needed for the form.
+if [[ -n "$HTML" ]]; then
+  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+else
+  MD=$(jina_fetch "$URL")
+  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+fi

--- a/.claude/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.claude/skills/generate-application/scripts/fetch-application-form.sh
@@ -13,24 +13,32 @@
 # Output: JSON to stdout
 #   {
 #     "url": "...",          input job posting URL
-#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
+#     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|factorial|generic",
 #     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
+#     "needs_browser": true|false,  true when the form wasn't captured (source apply-page/none AND questions empty)
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
 #   }
+#
+# needs_browser is the handoff signal: when true, the returned questions are empty
+# and form_text is at best a thin JD blob, so the calling agent MUST open apply_url
+# with browser tools (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text)
+# to read the real form instead of trusting this output. When false, questions[] is
+# authoritative and no browser step is needed.
 #
 # Strategy per ATS:
 #   greenhouse       → public boards API with ?questions=true (full structured form)
 #   workable         → public form API (v3, then v1)
 #   lever            → fetch {url}/apply HTML (server-rendered) and extract field labels
 #   smartrecruiters  → postings API for applyUrl, then Jina Reader on the apply page
-#   ashby            → {url}/application via Jina Reader (page is client-rendered JS)
+#   ashby            → public GraphQL posting API (full structured form); Jina Reader fallback
+#   factorial        → detect factorialhr.com, surface apply_url, hand off to browser
 #   generic          → scan job page HTML for an apply link, fetch it, extract labels
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
-# empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
+# empty questions list, source "none", and needs_browser true so the calling agent
+# knows to open apply_url in a browser instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -107,7 +115,15 @@ emit() {
     --arg source "$source" \
     --argjson questions "$questions" \
     --arg form_text "$form_text" \
-    '{url: $url, ats: $ats, apply_url: $apply_url, source: $source, questions: $questions, form_text: $form_text}'
+    '{
+       url: $url,
+       ats: $ats,
+       apply_url: $apply_url,
+       source: $source,
+       needs_browser: (($source == "apply-page" or $source == "none") and ($questions | length) == 0),
+       questions: $questions,
+       form_text: $form_text
+     }'
 }
 
 # fetch an apply page and emit best-effort results for a known ATS
@@ -219,14 +235,52 @@ if grep -qE 'jobs\.(eu\.)?lever\.co/[^/]+/[a-f0-9-]+' <<<"$URL"; then
 fi
 
 # ── Ashby ────────────────────────────────────────────────────────────────────
-# Apply form at {posting-url}/application; the page is client-rendered, so only
-# Jina Reader (which executes JS) can read it non-interactively.
+# Ashby exposes a public GraphQL endpoint (non-user-graphql, ApiJobPosting) that
+# returns the FULL application form — sections → fieldEntries → field — structured
+# and unauthenticated, just like Greenhouse. The apply page itself is client-
+# rendered JS, so Jina Reader is only a text fallback when the API path fails.
+# URL: jobs.ashbyhq.com/{org}/{jobPostingId}[/application]
 
 if grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+' <<<"$URL"; then
   BASE="${URL%%\?*}"
   BASE="${BASE%/}"
   BASE="${BASE%/application}"
   APPLY_URL="${BASE}/application"
+  ORG=$(sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|' <<<"$BASE")
+  JOB_ID=$(sed -E 's|.*/([A-Za-z0-9-]+)$|\1|' <<<"$BASE")
+
+  GQL=$(jq -n --arg org "$ORG" --arg jid "$JOB_ID" '{
+    operationName: "ApiJobPosting",
+    variables: {organizationHostedJobsPageName: $org, jobPostingId: $jid},
+    query: "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { applicationForm { sections { title fieldEntries { isRequired field } } } } }"
+  }')
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+    -H "Content-Type: application/json" \
+    -H "Origin: https://jobs.ashbyhq.com" \
+    --data-raw "$GQL" \
+    "https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting" 2>/dev/null || true)
+
+  if [[ -n "$RESPONSE" ]] && jq -e '.data.jobPosting.applicationForm.sections' <<<"$RESPONSE" >/dev/null 2>&1; then
+    # field is a JSON scalar carrying {title, type, selectableValues, ...}
+    QUESTIONS=$(jq '
+      [ (.data.jobPosting.applicationForm.sections // [])[]
+        | (.fieldEntries // [])[]
+        | {
+            label: (.field.title // ""),
+            type: (.field.type // "unknown"),
+            required: (.isRequired // null),
+            options: ((.field.selectableValues // [])
+                      | map(.label // .value // tostring)
+                      | if length == 0 then null else . end)
+          } ]
+      | map(select(.label != ""))' <<<"$RESPONSE" 2>/dev/null)
+    if [[ -n "${QUESTIONS:-}" && "$QUESTIONS" != "[]" ]]; then
+      emit "ashby" "$APPLY_URL" "api" "$QUESTIONS" ""
+      exit 0
+    fi
+  fi
+
+  # API path failed — degrade to Jina Reader text, then to a bare browser handoff.
   MD=$(jina_fetch "$APPLY_URL")
   if [[ -n "$MD" ]]; then
     emit "ashby" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
@@ -253,6 +307,26 @@ if grep -qE 'jobs\.smartrecruiters\.com/' <<<"$URL"; then
     emit "smartrecruiters" "$APPLY_URL" "apply-page" "[]" "$(head -c "$MAX_TEXT" <<<"$MD")"
   else
     emit "smartrecruiters" "$APPLY_URL" "none" "[]" ""
+  fi
+  exit 0
+fi
+
+# ── Factorial ────────────────────────────────────────────────────────────────
+# Factorial self-hosts job boards on {company}.factorialhr.com. The apply form is
+# client-rendered with no known public form endpoint, so surface a sensible
+# apply_url plus the job-page text and hand the form off to a browser.
+# URL: {company}.factorialhr.com/job_posting/{slug}  (or /jobs/...)
+
+if grep -qE 'factorialhr\.com' <<<"$URL"; then
+  BASE="${URL%%\?*}"
+  BASE="${BASE%/}"
+  APPLY_URL="$BASE"
+  HTML=$(fetch "$URL")
+  if [[ -n "$HTML" ]]; then
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  else
+    MD=$(jina_fetch "$URL")
+    emit "factorial" "$APPLY_URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
   fi
   exit 0
 fi

--- a/.claude/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.claude/skills/generate-application/scripts/fetch-application-form.sh
@@ -14,7 +14,7 @@
 #   {
 #     "url": "...",          input job posting URL
 #     "ats": "greenhouse|lever|ashby|workable|smartrecruiters|generic",
-#     "apply_url": "...",    deep link to the actual application form ("" if not found)
+#     "apply_url": "...",    deep link to the application form (falls back to the job URL if not found; check source)
 #     "source": "api|apply-page|none",
 #     "questions": [ {"label": "...", "type": "...", "required": true|false|null, "options": [...]|null} ],
 #     "form_text": "..."     raw apply-page text when questions could not be fully structured
@@ -30,7 +30,7 @@
 #
 # The script never fails hard: each strategy degrades to the next, ending with an
 # empty questions list and source "none" so the calling agent knows to open
-# apply_url in a browser (mcp__claude-in-chrome__navigate + get_page_text) instead.
+# apply_url in a browser (mcp__claude-in-chrome__navigate + mcp__claude-in-chrome__get_page_text) instead.
 #
 # Requires: curl, jq. Optional: JINA_API_KEY (for JS-rendered apply pages).
 
@@ -286,8 +286,8 @@ fi
 # No apply link found — return the job page text so the agent can look for
 # embedded questions, and signal that a browser is needed for the form.
 if [[ -n "$HTML" ]]; then
-  emit "generic" "" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
+  emit "generic" "$URL" "none" "[]" "$(strip_html <<<"$HTML" | head -c "$MAX_TEXT")"
 else
   MD=$(jina_fetch "$URL")
-  emit "generic" "" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
+  emit "generic" "$URL" "none" "[]" "$(head -c "$MAX_TEXT" <<<"${MD:-}")"
 fi

--- a/.claude/skills/generate-application/scripts/fetch-application-form.sh
+++ b/.claude/skills/generate-application/scripts/fetch-application-form.sh
@@ -63,7 +63,7 @@ jina_fetch() {
 }
 
 strip_html() {
-  sed -E 's/<script[^>]*>[^<]*<\/script>//g; s/<style[^>]*>[^<]*<\/style>//g; s/<[^>]*>/ /g' \
+  perl -0777 -pe 's{<script\b[^>]*>.*?</script>}{}gis; s{<style\b[^>]*>.*?</style>}{}gis; s{<[^>]*>}{ }g' \
     | sed -E 's/&amp;/\&/g; s/&#x27;/'\''/g; s/&#39;/'\''/g; s/&quot;/"/g; s/&nbsp;/ /g' \
     | sed -E 's/[[:space:]]+/ /g' \
     | sed '/^[[:space:]]*$/d'


### PR DESCRIPTION
The find-kristian-jobs and generate-application skills only fetched the
job ad, never the apply form itself, so application packages missed the
actual screening questions, essay prompts, and factual fields.

- New scripts/fetch-application-form.sh (bundled with both skills):
  detects the ATS from the URL and returns {ats, apply_url, source,
  questions, form_text} JSON. Structured questions via the Greenhouse
  boards API (?questions=true) and Workable form API; apply-page label
  extraction for Lever and generic career sites; Jina Reader for
  JS-rendered Ashby forms; SmartRecruiters applyUrl lookup. Degrades
  gracefully to source "none" so the agent knows to use browser tools.
- generate-application: new mandatory Step 2 (fetch form + classify
  questions) and Step 9 (application-questions.md with drafted essay
  answers, factual answers from the profile, [FILL ME] placeholders for
  personal facts, honest flagging of knockout screeners). Fixed broken
  $CLAUDE_PLUGIN_ROOT reference paths (no plugin manifest exists) to
  repo-relative paths.
- find-kristian-jobs: apply_url + form snapshot in Mode 3 Deep Analysis;
  Mode 4 now requires form questions (or an explicit unreadable-form
  note) plus an Application Form Answers section in the package.
- .agents mirrors updated; fixed nonexistent .Codex/skills/ script paths
  to .agents/skills/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017CCGnuR63fmFtBSQGrCPhT