### PR TITLE
Add llms.txt and agent-accessibility endpoints

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -67,6 +67,12 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addShortcode("year", () => `${new Date().getFullYear()}`);
 
+  // Case study markdown sources, used to build /llms.txt, /llms-full.txt
+  // and the per-page markdown mirrors for AI agents
+  eleventyConfig.addCollection("caseStudies", (collectionApi) =>
+    collectionApi.getFilteredByGlob("src/work/*.md")
+  );
+
   // Set directories
   return {
     dir: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const EleventyImage = require("@11ty/eleventy-img");
+const site = require("./src/_data/site.js");
 
 function escapeAttr(str) {
   return String(str).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -71,6 +72,14 @@ module.exports = function(eleventyConfig) {
   // and the per-page markdown mirrors for AI agents
   eleventyConfig.addCollection("caseStudies", (collectionApi) =>
     collectionApi.getFilteredByGlob("src/work/*.md")
+  );
+
+  // Absolute URLs for agent-facing endpoints (llms.txt, sitemap, robots)
+  eleventyConfig.addFilter("absoluteUrl", (path) => new URL(path, site.url).href);
+  // URL of a page's markdown mirror (see work-md.njk)
+  eleventyConfig.addFilter(
+    "mdMirrorUrl",
+    (pageUrl) => new URL(`${pageUrl}${pageUrl.endsWith("/") ? "" : "/"}index.md`, site.url).href
   );
 
   // Set directories

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -29,7 +29,6 @@
   
   <link rel="icon" href="{{ '/favicon.ico' | url }}" type="image/x-icon" sizes="16x16">
   <link rel="alternate" type="text/plain" href="{{ '/llms.txt' | url }}" title="LLM-friendly summary of this site">
-  <link rel="sitemap" type="application/xml" href="{{ '/sitemap.xml' | url }}">
 
   <!-- Resource hints -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -28,6 +28,8 @@
   <meta name="twitter:image:alt" content="{{ site.title }}">
   
   <link rel="icon" href="{{ '/favicon.ico' | url }}" type="image/x-icon" sizes="16x16">
+  <link rel="alternate" type="text/plain" href="{{ '/llms.txt' | url }}" title="LLM-friendly summary of this site">
+  <link rel="sitemap" type="application/xml" href="{{ '/sitemap.xml' | url }}">
 
   <!-- Resource hints -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/llms-full.njk
+++ b/src/llms-full.njk
@@ -22,7 +22,7 @@ Password-protected case studies are listed with metadata only; contact the autho
 
 - Company: {{ item.data.company }}
 - Tags: {{ item.data.tags | join(", ") }}
-- URL: https://kjgarza.github.io{{ item.url }}
+- URL: {{ item.url | absoluteUrl }}
 
 {% if item.data.passwordProtected -%}
 {{ item.data.description }}

--- a/src/llms-full.njk
+++ b/src/llms-full.njk
@@ -1,0 +1,48 @@
+---
+permalink: /llms-full.txt
+eleventyExcludeFromCollections: true
+---
+# {{ site.title }} — full site content
+
+> {{ site.description }}
+
+{{ site.title }} is a {{ site.schema_org.jobTitle }} at {{ site.schema_org.affiliation.name }} (ORCID: 0000-0003-3484-6875).
+
+- Currently: {{ site.bio.currently }}
+- Previously: {{ site.bio.past }}
+- Find me: {{ site.bio.findMe }}
+- Contact: {{ site.author.email }} | GitHub: {{ site.author.github }} | LinkedIn: {{ site.author.linkedin }}
+
+Password-protected case studies are listed with metadata only; contact the author for access.
+
+---
+
+{% for item in collections.caseStudies %}
+# {{ item.data.title }}
+
+- Company: {{ item.data.company }}
+- Tags: {{ item.data.tags | join(", ") }}
+- URL: https://kjgarza.github.io{{ item.url }}
+
+{% if item.data.passwordProtected -%}
+{{ item.data.description }}
+
+*Full content is password-protected. Contact {{ site.author.email }} for access.*
+{%- else -%}
+{{ item.rawInput | trim }}
+{%- endif %}
+
+---
+{% endfor %}
+# Tools
+
+{% for tool in tools -%}
+- [{{ tool.name }}]({{ tool.link }}) ({{ tool.type }}): {{ tool.description }}
+{% endfor %}
+---
+
+# Publications
+
+{% for pub in publications -%}
+- [{{ pub.title }}]({{ pub.id }}) ({{ pub.publicationYear }})
+{% endfor %}

--- a/src/llms.njk
+++ b/src/llms.njk
@@ -13,12 +13,12 @@ eleventyExcludeFromCollections: true
 - Find me: {{ site.bio.findMe }}
 - Contact: {{ site.author.email }} | GitHub: {{ site.author.github }} | LinkedIn: {{ site.author.linkedin }}
 
-Case studies marked with a `.md` link have a plain-markdown mirror at `<page-url>index.md`. Pages without one are password-protected; contact the author for access. The complete public content of this site is concatenated in [llms-full.txt](https://kjgarza.github.io/llms-full.txt).
+Case studies marked with a `.md` link have a plain-markdown mirror at `<page-url>index.md`. Pages without one are password-protected; contact the author for access. The complete public content of this site is concatenated in [llms-full.txt]({{ "/llms-full.txt" | absoluteUrl }}).
 
 ## Work
 
 {% for item in collections.caseStudies -%}
-- [{{ item.data.title }}](https://kjgarza.github.io{{ item.url }}{% if not item.data.passwordProtected %}index.md{% endif %}): {{ item.data.company }} — {{ item.data.description }}{% if item.data.passwordProtected %} (password-protected){% endif %}
+- [{{ item.data.title }}]({% if item.data.passwordProtected %}{{ item.url | absoluteUrl }}{% else %}{{ item.url | mdMirrorUrl }}{% endif %}): {{ item.data.company }} — {{ item.data.description }}{% if item.data.passwordProtected %} (password-protected){% endif %}
 {% endfor %}
 ## Tools
 
@@ -32,8 +32,8 @@ Case studies marked with a `.md` link have a plain-markdown mirror at `<page-url
 {% endfor %}
 ## Optional
 
-- [CV](https://kjgarza.github.io/cv/): full curriculum vitae with skills and experience
-- [Work index](https://kjgarza.github.io/work/): HTML overview of all case studies
-- [Technology Radar](https://kjgarza.github.io/radar/): personal radar of tools, frameworks, and techniques
-- [Profile API](https://kjgarza.github.io/api/data.json): machine-readable profile data (JSON)
-- [Sitemap](https://kjgarza.github.io/sitemap.xml)
+- [CV]({{ "/cv/" | absoluteUrl }}): full curriculum vitae with skills and experience
+- [Work index]({{ "/work/" | absoluteUrl }}): HTML overview of all case studies
+- [Technology Radar]({{ "/radar/" | absoluteUrl }}): personal radar of tools, frameworks, and techniques
+- [Profile API]({{ "/api/data.json" | absoluteUrl }}): machine-readable profile data (JSON)
+- [Sitemap]({{ "/sitemap.xml" | absoluteUrl }})

--- a/src/llms.njk
+++ b/src/llms.njk
@@ -1,0 +1,39 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# {{ site.title }}
+
+> {{ site.description }}
+
+{{ site.title }} is a {{ site.schema_org.jobTitle }} at {{ site.schema_org.affiliation.name }} (ORCID: 0000-0003-3484-6875).
+
+- Currently: {{ site.bio.currently }}
+- Previously: {{ site.bio.past }}
+- Find me: {{ site.bio.findMe }}
+- Contact: {{ site.author.email }} | GitHub: {{ site.author.github }} | LinkedIn: {{ site.author.linkedin }}
+
+Case studies marked with a `.md` link have a plain-markdown mirror at `<page-url>index.md`. Pages without one are password-protected; contact the author for access. The complete public content of this site is concatenated in [llms-full.txt](https://kjgarza.github.io/llms-full.txt).
+
+## Work
+
+{% for item in collections.caseStudies -%}
+- [{{ item.data.title }}](https://kjgarza.github.io{{ item.url }}{% if not item.data.passwordProtected %}index.md{% endif %}): {{ item.data.company }} — {{ item.data.description }}{% if item.data.passwordProtected %} (password-protected){% endif %}
+{% endfor %}
+## Tools
+
+{% for tool in tools -%}
+- [{{ tool.name }}]({{ tool.link }}): {{ tool.description }}
+{% endfor %}
+## Publications
+
+{% for pub in publications -%}
+- [{{ pub.title }}]({{ pub.id }}) ({{ pub.publicationYear }})
+{% endfor %}
+## Optional
+
+- [CV](https://kjgarza.github.io/cv/): full curriculum vitae with skills and experience
+- [Work index](https://kjgarza.github.io/work/): HTML overview of all case studies
+- [Technology Radar](https://kjgarza.github.io/radar/): personal radar of tools, frameworks, and techniques
+- [Profile API](https://kjgarza.github.io/api/data.json): machine-readable profile data (JSON)
+- [Sitemap](https://kjgarza.github.io/sitemap.xml)

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -3,10 +3,10 @@ permalink: /robots.txt
 eleventyExcludeFromCollections: true
 ---
 # AI agents and crawlers are welcome.
-# Start here for an LLM-friendly overview: https://kjgarza.github.io/llms.txt
-# Full plain-text content: https://kjgarza.github.io/llms-full.txt
+# Start here for an LLM-friendly overview: {{ "/llms.txt" | absoluteUrl }}
+# Full plain-text content: {{ "/llms-full.txt" | absoluteUrl }}
 
 User-agent: *
 Allow: /
 
-Sitemap: https://kjgarza.github.io/sitemap.xml
+Sitemap: {{ "/sitemap.xml" | absoluteUrl }}

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -1,0 +1,12 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+---
+# AI agents and crawlers are welcome.
+# Start here for an LLM-friendly overview: https://kjgarza.github.io/llms.txt
+# Full plain-text content: https://kjgarza.github.io/llms-full.txt
+
+User-agent: *
+Allow: /
+
+Sitemap: https://kjgarza.github.io/sitemap.xml

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -7,7 +7,7 @@ eleventyExcludeFromCollections: true
 {% for item in collections.all -%}
 {% if "/work/case-studies/" not in item.url -%}
   <url>
-    <loc>https://kjgarza.github.io{{ item.url }}</loc>
+    <loc>{{ item.url | absoluteUrl | e }}</loc>
   </url>
 {% endif -%}
 {% endfor -%}

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -1,0 +1,14 @@
+---
+permalink: /sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in collections.all -%}
+{% if "/work/case-studies/" not in item.url -%}
+  <url>
+    <loc>https://kjgarza.github.io{{ item.url }}</loc>
+  </url>
+{% endif -%}
+{% endfor -%}
+</urlset>

--- a/src/work-md.njk
+++ b/src/work-md.njk
@@ -10,7 +10,8 @@
   },
   eleventyExcludeFromCollections: true,
   eleventyComputed: {
-    permalink: (data) => `${data.study.url}index.md`,
+    permalink: (data) =>
+      `${data.study.url}${data.study.url.endsWith("/") ? "" : "/"}index.md`,
   },
 }
 ---
@@ -18,7 +19,7 @@
 
 - Company: {{ study.data.company }}
 - Tags: {{ study.data.tags | join(", ") }}
-- Canonical URL: https://kjgarza.github.io{{ study.url }}
+- Canonical URL: {{ study.url | absoluteUrl }}
 - Author: {{ site.title }} ({{ site.author.email }})
 
 {{ study.rawInput | trim }}

--- a/src/work-md.njk
+++ b/src/work-md.njk
@@ -1,0 +1,24 @@
+---js
+{
+  pagination: {
+    data: "collections.caseStudies",
+    size: 1,
+    alias: "study",
+    // Password-protected case studies get no markdown mirror
+    before: (paginationData) =>
+      paginationData.filter((item) => !item.data.passwordProtected),
+  },
+  eleventyExcludeFromCollections: true,
+  eleventyComputed: {
+    permalink: (data) => `${data.study.url}index.md`,
+  },
+}
+---
+# {{ study.data.title }}
+
+- Company: {{ study.data.company }}
+- Tags: {{ study.data.tags | join(", ") }}
+- Canonical URL: https://kjgarza.github.io{{ study.url }}
+- Author: {{ site.title }} ({{ site.author.email }})
+
+{{ study.rawInput | trim }}


### PR DESCRIPTION
Make the site accessible to AI agents and crawlers:

- /llms.txt: llms.txt-spec index generated from site data (bio, work,
  tools, publications), with links to markdown mirrors
- /llms-full.txt: full plain-text content of all public case studies;
  password-protected studies are listed with metadata only
- /work/<slug>/index.md: per-case-study markdown mirrors (skipping
  password-protected ones) via a paginated template
- /robots.txt: allow all agents, point to sitemap and llms.txt
- /sitemap.xml: generated from all page URLs
- base layout: discovery <link> tags for llms.txt and sitemap

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FnrJWtgaVEPGMnzKroiD86