### PR TITLE
Add job-pipeline orchestrator skill

### DIFF
--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -6,10 +6,10 @@
 #
 # Output: JSON to stdout
 #   { "url": "...", "posted_date": "YYYY-MM-DD|unknown", "status": "open|closed|unknown",
-#     "content": "...", "questions": [{"label": "...", "required": true, "type": "..."}] }
+#     "content": "...",
+#     "questions": [{"label": "...", "required": true, "type": "...", "options": ["..."]}] }
 #
 # "questions" is the application form's fields when the ATS exposes them
-# (currently Greenhouse only); empty array otherwise.
 #
 # Fetch chain:
 #   1. Greenhouse public API (if URL matches greenhouse.io pattern) — best for dates

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -5,7 +5,11 @@
 #   ./scripts/fetch-job.sh <job-url>
 #
 # Output: JSON to stdout
-#   { "url": "...", "posted_date": "YYYY-MM-DD|unknown", "status": "open|closed|unknown", "content": "..." }
+#   { "url": "...", "posted_date": "YYYY-MM-DD|unknown", "status": "open|closed|unknown",
+#     "content": "...", "questions": [{"label": "...", "required": true, "type": "..."}] }
+#
+# "questions" is the application form's fields when the ATS exposes them
+# (currently Greenhouse only); empty array otherwise.
 #
 # Fetch chain:
 #   1. Greenhouse public API (if URL matches greenhouse.io pattern) — best for dates
@@ -48,13 +52,14 @@ detect_closed() {
 }
 
 emit_json() {
-  local url="$1" posted_date="$2" status="$3" content="$4"
+  local url="$1" posted_date="$2" status="$3" content="$4" questions="${5:-[]}"
   jq -n \
     --arg url "$url" \
     --arg posted_date "$posted_date" \
     --arg status "$status" \
     --arg content "$content" \
-    '{url: $url, posted_date: $posted_date, status: $status, content: $content}'
+    --argjson questions "$questions" \
+    '{url: $url, posted_date: $posted_date, status: $status, content: $content, questions: $questions}'
 }
 
 # ── Greenhouse public API ─────────────────────────────────────────────────────
@@ -66,7 +71,7 @@ if echo "$URL" | grep -qE 'greenhouse\.io/([^/]+)/jobs/([0-9]+)'; then
   BOARD=$(echo "$URL" | grep -oE 'greenhouse\.io/([^/]+)/jobs' | cut -d'/' -f2)
   JOB_ID=$(echo "$URL" | grep -oE '/jobs/([0-9]+)' | grep -oE '[0-9]+')
 
-  API_URL="https://api.greenhouse.io/v1/boards/${BOARD}/jobs/${JOB_ID}"
+  API_URL="https://api.greenhouse.io/v1/boards/${BOARD}/jobs/${JOB_ID}?questions=true"
   RESPONSE=$(curl -sf --max-time "$TIMEOUT" "$API_URL" 2>/dev/null || echo "")
 
   if [[ -n "$RESPONSE" ]] && echo "$RESPONSE" | jq -e '.id' >/dev/null 2>&1; then
@@ -77,7 +82,14 @@ if echo "$URL" | grep -qE 'greenhouse\.io/([^/]+)/jobs/([0-9]+)'; then
     POSTED_DATE=$(echo "$UPDATED" | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}' | head -1 || echo "unknown")
     CONTENT="# ${TITLE}\nLocation: ${LOCATION}\nUpdated: ${UPDATED}\n\n$(echo "$RESPONSE" | jq -r '.content // ""' | sed 's/<[^>]*>//g')"
     STATUS="open"  # If the API returns a job, it's live
-    emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT"
+    # Application form fields (label, required, type, select options if any)
+    QUESTIONS=$(echo "$RESPONSE" | jq -c '[.questions[]? | {
+      label: .label,
+      required: .required,
+      type: (.fields[0].type // "unknown"),
+      options: ([.fields[0].values[]?.label] | if length > 0 then . else null end)
+    }]' 2>/dev/null || echo "[]")
+    emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT" "$QUESTIONS"
     exit 0
   fi
 fi

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -87,7 +87,7 @@ if echo "$URL" | grep -qE 'greenhouse\.io/([^/]+)/jobs/([0-9]+)'; then
       label: .label,
       required: .required,
       type: (.fields[0].type // "unknown"),
-      options: ([.fields[0].values[]?.label] | if length > 0 then . else null end)
+      options: ([.fields[0].values[]?.label])
     }]' 2>/dev/null || echo "[]")
     emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT" "$QUESTIONS"
     exit 0

--- a/.claude/skills/job-pipeline/SKILL.md
+++ b/.claude/skills/job-pipeline/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: job-pipeline
+description: Autonomous end-to-end job pipeline for Kristian — search, score, decide, prepare full application packages (CV, cover letter, application-form answers, contacts), track state, and notify. Use for "run the job pipeline", "what's in my pipeline", "any new jobs", scheduled/unattended job search runs, or when Kristian wants the whole search→apply flow without prompting each step. Composes find-kristian-jobs, generate-application, and find-linkedin-contacts.
+argument-hint: "[run | status | approve <url-or-slug> | submit <url-or-slug>]"
+---
+
+# job-pipeline
+
+End-to-end orchestrator. One invocation takes a job from *unknown* to *ready-to-submit package + outreach plan* with no human prompting in between. The human is only needed at two points: setting policy (once, in `references/decision-policy.md`) and approving submission.
+
+## State: the ledger
+
+`leads/pipeline.json` at the repo root is the single source of truth. **Read it before doing anything; write it after every state change.**
+
+- Keyed by job URL. Statuses: `discovered → scored → preparing → prepared → notified → approved → submitted → interviewing → offer`, terminal: `rejected | passed | expired`.
+- Never re-fetch, re-score, or re-prepare a URL that's already in the ledger unless its status is `discovered` or the user explicitly asks. This is what stops every run from redoing old work.
+- When a posting turns out closed/older than 5 months, set status `expired` with a note — keep the entry so it stays deduplicated.
+- Update the `updated` field on every write.
+
+## Decision policy
+
+Read `references/decision-policy.md` before scoring or deciding anything. It encodes Kristian's goals (innovation, compensation, speed) as score modifiers and action thresholds. The policy decides what happens to each job — not the user, not ad-hoc judgment.
+
+## Command routing
+
+| Input | Mode |
+|-------|------|
+| `/job-pipeline` or `/job-pipeline run` | **Full run** (the default, also used by cron) |
+| `/job-pipeline status` | **Status report** from the ledger |
+| `/job-pipeline approve <url-or-slug>` | Mark approved, proceed to submission prep |
+| `/job-pipeline submit <url-or-slug>` | **Assisted submission** via browser |
+
+---
+
+## Mode: Full run
+
+Designed to work unattended (cron, remote trigger, `--print`). Never ask interactive questions in this mode; make the policy decision and record it.
+
+### 1 — Sweep the existing pipeline first (don't miss what you already have)
+
+Before searching for anything new:
+
+1. Read `leads/pipeline.json`.
+2. For every job in status `prepared` or `notified`: re-check it's still open (`fetch-job.sh <url>`, check `.status`). If closed → status `expired`, flag prominently in the final report ("missed: X closed before submission").
+3. For every `prepared` job missing `answers: true`: generate `application-questions.md` now using generate-application Step 9, set `answers: true`.
+4. For every GO job missing `contacts: true`: invoke `find-linkedin-contacts`, save output to the package folder, set `contacts: true`.
+5. Flag any job sitting in `prepared`/`notified` for more than 7 days — these are the leaks; speed is a stated goal.
+
+### 2 — Search
+
+Invoke the `find-kristian-jobs` skill, Full Search mode (its budgets and freshness rules apply). Before scoring, drop every URL already present in the ledger. Add each genuinely new posting to the ledger as `discovered`.
+
+### 3 — Score and decide
+
+Score each new posting with the find-kristian-jobs matrix, then apply the modifiers and thresholds from `references/decision-policy.md`. Record `score`, `recommendation`, and the decided action in the ledger (`scored`). Apply the policy actions:
+
+- **AUTO-PREPARE**: run the full generate-application skill (analysis, cv-data.js, cover letter, **application-questions.md**) and `find-linkedin-contacts`, end-to-end, without asking. Ledger → `prepared`, with `package`, `answers`, `contacts` fields set.
+- **NOTIFY-ONLY**: ledger → `scored`, include in report for human decision.
+- **PASS**: ledger → `passed` with one-line reason. Never silently drop a job — every discovered URL gets a ledger entry.
+
+### 4 — Report and notify
+
+Write the run summary to `leads/YYYY-MM-DD-pipeline-run.md`:
+
+- New jobs found / prepared / passed (with reasons)
+- Pipeline health: stale items, expired items ("missed opportunities"), items awaiting approval
+- For each prepared package: path, score, deadline if known, and the exact next action ("review answers, then `/job-pipeline submit <url>`")
+- Any `⚠️ NEEDS INPUT` fields from application-questions.md files
+
+Then push the summary to Kristian (he is not at the terminal during scheduled runs):
+1. **Telegram** if the channel is available: send a short digest (counts + top items + needed decisions) via the telegram reply tool.
+2. Otherwise `PushNotification` with a one-line summary.
+3. The `openclaw system event` command if running inside the OpenClaw container (detect via `$OPENCLAW_*` env or `/home/node/.openclaw` existing).
+
+### Run budget
+
+One full run = find-kristian-jobs budgets + max 3 AUTO-PREPARE packages. If more than 3 jobs qualify, prepare the 3 highest-scored and leave the rest as `scored` with action `AUTO-PREPARE (deferred)` — the next run picks them up.
+
+---
+
+## Mode: Status report
+
+Read the ledger, print a table grouped by status (active first), flag: stale `prepared` items, unknown deadlines on GO jobs, `⚠️ NEEDS INPUT` markers, anything `expired` in the last 14 days. End with the single most valuable next action.
+
+## Mode: Approve
+
+Set the job's status to `approved`. Verify the package is complete (analysis, cv-data.js, cover letter, application-questions.md, contacts); generate anything missing. Re-check the posting is still open. Then offer `/job-pipeline submit`.
+
+## Mode: Assisted submission (human stays in the loop)
+
+Submission is the one irreversible, outward-facing step — it is **never** done unattended.
+
+1. Job must be `approved` (or the user is asking interactively right now — that counts as approval).
+2. Open the apply page: `mcp__claude-in-chrome__tabs_create_mcp` → `mcp__claude-in-chrome__navigate` → `mcp__claude-in-chrome__read_page`.
+3. Fill every field from `application-questions.md` using `mcp__claude-in-chrome__form_input`; upload the CV PDF with `mcp__claude-in-chrome__file_upload` (ask for the path if no PDF exists in the package — or build it from cv-data.js first).
+4. Refuse to proceed if any `⚠️ NEEDS INPUT` field is unresolved.
+5. **Stop before clicking the final submit button.** Screenshot the filled form (`mcp__claude-in-chrome__computer`, screenshot action), show it, and get an explicit yes. Only then click submit.
+6. Ledger → `submitted` with date; suggest sending the P1 outreach messages from the contacts file.
+
+---
+
+## Hard rules
+
+- Ledger first, ledger last — a run that doesn't update `leads/pipeline.json` is a failed run.
+- Never submit, send, or publish anything external without explicit human approval in the same conversation.
+- Honest packages: same authenticity rules as generate-application — no invented experience, gaps stated.
+- All money/relocation/start-date answers come from the decision policy, never improvised.

--- a/.claude/skills/job-pipeline/SKILL.md
+++ b/.claude/skills/job-pipeline/SKILL.md
@@ -12,6 +12,7 @@ End-to-end orchestrator. One invocation takes a job from *unknown* to *ready-to-
 
 `leads/pipeline.json` at the repo root is the single source of truth. **Read it before doing anything; write it after every state change.**
 
+- If `leads/` or `leads/pipeline.json` doesn't exist yet, create the directory and initialise the ledger to `{}` (then proceed).
 - Keyed by job URL. Statuses: `discovered → scored → preparing → prepared → notified → approved → submitted → interviewing → offer`, terminal: `rejected | passed | expired`.
 - Never re-fetch, re-score, or re-prepare a URL that's already in the ledger unless its status is `discovered` or the user explicitly asks. This is what stops every run from redoing old work.
 - When a posting turns out closed/older than 5 months, set status `expired` with a note — keep the entry so it stays deduplicated.

--- a/.claude/skills/job-pipeline/references/decision-policy.md
+++ b/.claude/skills/job-pipeline/references/decision-policy.md
@@ -1,0 +1,57 @@
+# Decision Policy
+
+Kristian's stated goals, in priority order:
+1. **Innovative work** — frontier AI, research infrastructure, things that didn't exist 2 years ago. Not maintenance, not generic SaaS.
+2. **Very good money** — compensation is a first-class dimension, not an afterthought.
+3. **Speed** — move fast, don't let opportunities expire while packages sit in Draft.
+
+This file is the contract for unattended decisions. Edit the numbers here; the pipeline obeys them.
+
+## Score modifiers (applied after the base find-kristian-jobs score)
+
+| Signal | Modifier |
+|--------|----------|
+| Frontier AI lab or AI-native product company (Anthropic, Mistral, Cohere, HF, etc.) | +5 |
+| Posting lists salary ≥ comp target (see below) | +5 |
+| Posting lists salary clearly below comp floor | −15 |
+| No salary listed | 0 (flag "comp unknown" in report — resolve via levels.fyi/Glassdoor lookup when preparing) |
+| Role is primarily maintenance/legacy/internal tooling | −10 |
+| Application deadline within 14 days | flag URGENT, prioritize in prepare queue |
+
+## Compensation targets
+
+> ⚠️ EDIT ME — placeholders based on Berlin Staff/Principal AI market, not confirmed by Kristian.
+
+| Parameter | Value |
+|-----------|-------|
+| Comp floor (base, EUR) | 110,000 |
+| Comp target (base, EUR) | 140,000+ or equivalent total comp |
+| Salary-expectation answer for forms | "€130,000–150,000 base depending on total package" (adjust per company tier) |
+| Notice period answer | 3 months (German standard — confirm contract) |
+| Start date answer | per notice period |
+| Relocation | Open for exceptional roles (e.g. London/Zurich frontier labs); prefer Berlin or remote EU |
+
+## Action thresholds (modified score)
+
+| Modified score | Action |
+|----------------|--------|
+| ≥ 75 | **AUTO-PREPARE** — full package + answers + contacts, no human prompt |
+| 60–74 | **NOTIFY-ONLY** — scored entry in report; human decides whether to prepare |
+| < 60 | **PASS** — ledger entry with one-line reason |
+
+Exception: any score ≥ 60 at a Tier-1 target company (see find-kristian-jobs `references/target-companies.md`) is upgraded to AUTO-PREPARE — don't miss frontier-lab openings over a borderline score.
+
+## Speed SLAs
+
+| Event | Deadline |
+|-------|----------|
+| New AUTO-PREPARE job discovered | package ready same run |
+| Package `prepared` | surfaced for approval in every report until acted on |
+| `prepared` > 7 days old | escalate: top of report, Telegram ping |
+| Posting closes while `prepared` | record as missed opportunity in report — these are the failures to learn from |
+
+## Never autonomous
+
+- Clicking submit on an application
+- Sending LinkedIn/email outreach
+- Committing salary numbers different from this file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,5 +91,5 @@ This repo doubles as Kristian's job-search system. The orchestrator is the `job-
 - **State ledger**: `leads/pipeline.json` — single source of truth, keyed by job URL. Read it before fetching/scoring/preparing any job; update it after. Never redo work for a URL already in it.
 - **Decision policy**: `.claude/skills/job-pipeline/references/decision-policy.md` — goals, comp targets, auto-prepare thresholds. Unattended decisions follow this file.
 - **Skill chain**: `job-pipeline` → `find-kristian-jobs` (search/score) → `generate-application` (analysis, cv-data.js, cover letter, application-questions.md) → `find-linkedin-contacts` (outreach).
-- **Packages**: `applications/YYYY-MM-DD-[company]-[role]/` — every package must include `application-questions.md` (draft answers for the actual ATS form; questions come from `fetch-application-form.sh`, falling back to `fetch-job.sh` `.questions`).
+- **Packages**: `applications/YYYY-MM-DD-[company]-[role-slug]/` — every package must include `application-questions.md` (draft answers for the actual ATS form; questions come from `fetch-application-form.sh`, falling back to `fetch-job.sh` `.questions`).
 - **Hard rule**: never submit an application or send outreach without explicit human approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,13 @@ Tailwind utility classes are used throughout templates but the CSS is pre-compil
 ### Contact form
 
 The "Get in touch" button uses [Tally](https://tally.so) embedded forms (`data-tally-open="3XjAKz"`). The Tally embed script is loaded in `base.njk`.
+
+## Job Search Pipeline
+
+This repo doubles as Kristian's job-search system. The orchestrator is the `job-pipeline` skill — prefer it over invoking the lower-level skills directly.
+
+- **State ledger**: `leads/pipeline.json` — single source of truth, keyed by job URL. Read it before fetching/scoring/preparing any job; update it after. Never redo work for a URL already in it.
+- **Decision policy**: `.claude/skills/job-pipeline/references/decision-policy.md` — goals, comp targets, auto-prepare thresholds. Unattended decisions follow this file.
+- **Skill chain**: `job-pipeline` → `find-kristian-jobs` (search/score) → `generate-application` (analysis, cv-data.js, cover letter, application-questions.md) → `find-linkedin-contacts` (outreach).
+- **Packages**: `applications/YYYY-MM-DD-[company]-[role]/` — every package must include `application-questions.md` (draft answers for the actual ATS form; questions come from `fetch-application-form.sh`, falling back to `fetch-job.sh` `.questions`).
+- **Hard rule**: never submit an application or send outreach without explicit human approval.


### PR DESCRIPTION
## Summary
- New `job-pipeline` skill: unattended run/status/approve/submit orchestrator over `find-kristian-jobs` → `generate-application` → `find-linkedin-contacts`, backed by `leads/pipeline.json` ledger and a decision policy (`references/decision-policy.md`).
- `fetch-job.sh` now returns Greenhouse application form questions (`label`/`required`/`type`/`options`) alongside job content.
- `CLAUDE.md` documents the pipeline for future sessions; references `application-questions.md` to match `generate-application`'s current Step 9 output filename.

## Test plan
- [ ] `/job-pipeline status` runs against an existing `leads/pipeline.json`
- [ ] `/job-pipeline run` end-to-end on a fresh Greenhouse posting, confirm `application-questions.md` gets generated and ledger updates
- [ ] Manual review of `decision-policy.md` thresholds against Kristian's actual goals