### PR TITLE
Add Merantix Momentum to job search targets

### DIFF
--- a/.agents/skills/find-kristian-jobs/SKILL.md
+++ b/.agents/skills/find-kristian-jobs/SKILL.md
@@ -32,7 +32,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Total WebSearch queries (across all agents) | 15 |
 | Total job postings fetched & parsed | 20 |
 | Total subagents spawned (Mode 1) | 3 |
-| Career pages fetched per agent | 4 |
+| Career pages fetched per agent | 5 |
 
 If limits are reached before finding enough matches, report what was found and note the cap was hit.
 
@@ -134,13 +134,15 @@ leads/
 
 **Agent 1 — Direct Career Pages + LinkedIn Browser**
 
-Budget: max 4 career page fetches + LinkedIn browser search.
+Budget: max 5 career page fetches + LinkedIn browser search.
 
 1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://openai.com/careers/search/`
    - `https://www.anthropic.com/careers/jobs`
    - `https://holtzbrinck.com/en/jobs`
+   - `https://careers.merantix-aicampus.com/jobs?filter=eyJzZWFyY2hhYmxlX2xvY2F0aW9ucyI6WyJCZXJsaW4sIEdlcm1hbnkiXX0%3D` (Merantix AI Campus network, Berlin-filtered — covers Merantix Momentum and portfolio companies)
    - On each career page, check for a "posted date" or "last updated" field; skip any role posted more than 5 months ago or marked closed.
+   - The Merantix board runs on the Getro ATS, which `fetch-job.sh` does not handle and which 403s plain `curl` — always use the browser path for it.
 2. Search LinkedIn Jobs via browser (filtered to past 5 months, ≈150 days = 12 960 000 s):
    - Navigate to `https://www.linkedin.com/jobs/search/?keywords=AI+Engineer+research+infrastructure&location=Europe&f_TPR=r12960000`
    - Use `mcp__claude-in-chrome__get_page_text` to extract job titles, companies, URLs, **and posted dates**
@@ -160,6 +162,7 @@ Queries (pick the most relevant 5):
 - `"Head of AI" OR "Director of AI" open science remote Europe 2026`
 - `"Engineering Lead" developer tools research remote Europe 2026`
 - `Anthropic OR OpenAI OR "Google DeepMind" OR "Mistral AI" careers AI engineer Europe 2026`
+- `"Merantix Momentum" OR "Merantix AI Campus" careers machine learning engineer Berlin 2026`
 
 For each result, note the date shown in the search snippet. Discard any result whose snippet date is older than 5 months or whose title/snippet signals the role is closed.
 

--- a/.agents/skills/find-kristian-jobs/references/target-companies.md
+++ b/.agents/skills/find-kristian-jobs/references/target-companies.md
@@ -17,6 +17,7 @@
 |---------|-------------|--------------|-------|
 | **Holtzbrinck Digital / Holtzbrinck Group** | Parent of Springer Nature, Macmillan, Digital Science; major publishing/tech conglomerate | Digital, Technology, AI/ML | Career page: https://holtzbrinck.com/en/jobs — parent company perspective on Kristian's scholarly + AI skills |
 | **Springer Nature** | Academic publishing, AI transformation | Digital Technology, AI/ML | Deep scholarly domain knowledge + AI modernization angle. Part of Holtzbrinck Group |
+| **Merantix Momentum** | Berlin applied-AI company: builds production ML/LLM systems for enterprise and public-sector clients; part of the Merantix AI Campus venture studio | Engineering, Applied AI, ML Engineering | On-site Berlin (home city). Consulting-style delivery matches the Query Translation API / Dataset Discovery Agent work. Board: https://careers.merantix-aicampus.com/jobs?filter=eyJzZWFyY2hhYmxlX2xvY2F0aW9ucyI6WyJCZXJsaW4sIEdlcm1hbnkiXX0%3D — Getro ATS, needs browser fetch; the same board also lists other Merantix AI Campus portfolio companies |
 | **Chan Zuckerberg Initiative (CZI)** | Science infrastructure, open source values | Science Technology, Open Science | Direct overlap: scholarly infra + AI + open source |
 | **Crossref** | Core scholarly infrastructure, metadata | Engineering, Product | Deep DataCite collaboration history, PID expertise |
 | **ORCID** | Persistent identifiers, researcher identity | Engineering, Product | Direct domain expertise from DataCite PID Graph work |

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -32,7 +32,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Total WebSearch queries (across all agents) | 15 |
 | Total job postings fetched & parsed | 20 |
 | Total subagents spawned (Mode 1) | 3 |
-| Career pages fetched per agent | 4 |
+| Career pages fetched per agent | 5 |
 
 If limits are reached before finding enough matches, report what was found and note the cap was hit.
 
@@ -134,13 +134,15 @@ leads/
 
 **Agent 1 — Direct Career Pages + LinkedIn Browser**
 
-Budget: max 4 career page fetches + LinkedIn browser search.
+Budget: max 5 career page fetches + LinkedIn browser search.
 
 1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://openai.com/careers/search/`
    - `https://www.anthropic.com/careers/jobs`
    - `https://holtzbrinck.com/en/jobs`
+   - `https://careers.merantix-aicampus.com/jobs?filter=eyJzZWFyY2hhYmxlX2xvY2F0aW9ucyI6WyJCZXJsaW4sIEdlcm1hbnkiXX0%3D` (Merantix AI Campus network, Berlin-filtered — covers Merantix Momentum and portfolio companies)
    - On each career page, check for a "posted date" or "last updated" field; skip any role posted more than 5 months ago or marked closed.
+   - The Merantix board runs on the Getro ATS, which `fetch-job.sh` does not handle and which 403s plain `curl` — always use the browser path for it.
 2. Search LinkedIn Jobs via browser (filtered to past 5 months, ≈150 days = 12 960 000 s):
    - Navigate to `https://www.linkedin.com/jobs/search/?keywords=AI+Engineer+research+infrastructure&location=Europe&f_TPR=r12960000`
    - Use `mcp__claude-in-chrome__get_page_text` to extract job titles, companies, URLs, **and posted dates**
@@ -160,6 +162,7 @@ Queries (pick the most relevant 5):
 - `"Head of AI" OR "Director of AI" open science remote Europe 2026`
 - `"Engineering Lead" developer tools research remote Europe 2026`
 - `Anthropic OR OpenAI OR "Google DeepMind" OR "Mistral AI" careers AI engineer Europe 2026`
+- `"Merantix Momentum" OR "Merantix AI Campus" careers machine learning engineer Berlin 2026`
 
 For each result, note the date shown in the search snippet. Discard any result whose snippet date is older than 5 months or whose title/snippet signals the role is closed.
 

--- a/.claude/skills/find-kristian-jobs/references/target-companies.md
+++ b/.claude/skills/find-kristian-jobs/references/target-companies.md
@@ -17,6 +17,7 @@
 |---------|-------------|--------------|-------|
 | **Holtzbrinck Digital / Holtzbrinck Group** | Parent of Springer Nature, Macmillan, Digital Science; major publishing/tech conglomerate | Digital, Technology, AI/ML | Career page: https://holtzbrinck.com/en/jobs — parent company perspective on Kristian's scholarly + AI skills |
 | **Springer Nature** | Academic publishing, AI transformation | Digital Technology, AI/ML | Deep scholarly domain knowledge + AI modernization angle. Part of Holtzbrinck Group |
+| **Merantix Momentum** | Berlin applied-AI company: builds production ML/LLM systems for enterprise and public-sector clients; part of the Merantix AI Campus venture studio | Engineering, Applied AI, ML Engineering | On-site Berlin (home city). Consulting-style delivery matches the Query Translation API / Dataset Discovery Agent work. Board: https://careers.merantix-aicampus.com/jobs?filter=eyJzZWFyY2hhYmxlX2xvY2F0aW9ucyI6WyJCZXJsaW4sIEdlcm1hbnkiXX0%3D — Getro ATS, needs browser fetch; the same board also lists other Merantix AI Campus portfolio companies |
 | **Chan Zuckerberg Initiative (CZI)** | Science infrastructure, open source values | Science Technology, Open Science | Direct overlap: scholarly infra + AI + open source |
 | **Crossref** | Core scholarly infrastructure, metadata | Engineering, Product | Deep DataCite collaboration history, PID expertise |
 | **ORCID** | Persistent identifiers, researcher identity | Engineering, Product | Direct domain expertise from DataCite PID Graph work |


### PR DESCRIPTION
Adds Merantix to the `find-kristian-jobs` skill.

- **Tier 2 entry** in `target-companies.md` — Merantix Momentum, Berlin applied-AI company in the Merantix AI Campus venture studio.
- **Career page sweep** — the Berlin-filtered board URL added to Agent 1's fetch list. Board covers Momentum plus other AI Campus portfolio companies.
- **Track A query** — `"Merantix Momentum" OR "Merantix AI Campus" ...`.
- Career page budget 4 → 5 for the extra fetch.
- Mirrored identically into `.claude/skills/` and `.agents/skills/`.

## Notes
- The board runs on **Getro**, which `fetch-job.sh` has no handler for and which 403s plain `curl`. Documented that the browser path is required. A Getro handler in the fetch scripts would be a separate change.
- The specific posting linked in the request (*Working Student AI Full Stack Engineer m/f/d*) is a junior part-time Werkstudent role — off the senior/staff profile the skill targets. Adding the board captures Merantix's senior roles; no application generated for that posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)