### PR TITLE
Add two new case studies: Knowledge Graph Engine and Repo Atlas

### DIFF
--- a/src/_data/work.js
+++ b/src/_data/work.js
@@ -9,7 +9,7 @@ module.exports = [
     status: "published",
     image: "/assets/images/knowledge-graph-engine-hero.png",
     link: "/work/knowledge-graph-engine",
-    featured: true,
+    featured: false,
     gridClass: "col-span-2 row-span-1",
   },
   {
@@ -22,7 +22,7 @@ module.exports = [
     status: "published",
     image: "/assets/images/repo-atlas-hero.png",
     link: "/work/repo-atlas-catalogue",
-    featured: true,
+    featured: false,
     gridClass: "col-span-2 row-span-1",
   },
   {

--- a/src/_data/work.js
+++ b/src/_data/work.js
@@ -1,5 +1,31 @@
 module.exports = [
   {
+    id: "knowledge-graph-engine",
+    company: "Digital Science",
+    title: "Knowledge Graph Engine - Company Knowledge as a Graph for AI Agents",
+    description:
+      "Architected a hexagonal Effect-TS pipeline that extracts a Postgres-backed knowledge graph from company documents and serves it to AI agents over MCP.",
+    tags: ["Knowledge Graphs", "Effect-TS", "LLMs"],
+    status: "published",
+    image: "/assets/images/knowledge-graph-engine-hero.png",
+    link: "/work/knowledge-graph-engine",
+    featured: true,
+    gridClass: "col-span-2 row-span-1",
+  },
+  {
+    id: "repo-atlas-catalogue",
+    company: "Digital Science",
+    title: "Repo Atlas - Making 1,000+ Repos Discoverable with LLMs",
+    description:
+      "Built an LLM-powered catalogue that scans an entire GitHub org and answers \"does a repo already exist that does X?\" through an MCP server and web UI.",
+    tags: ["LLMs", "MCP", "TypeScript"],
+    status: "published",
+    image: "/assets/images/repo-atlas-hero.png",
+    link: "/work/repo-atlas-catalogue",
+    featured: true,
+    gridClass: "col-span-2 row-span-1",
+  },
+  {
     id: "query-translation-api",
     company: "Digital Science",
     title: "Query Translation API - Natural Language to Database Queries",

--- a/src/work/knowledge-graph-engine.md
+++ b/src/work/knowledge-graph-engine.md
@@ -1,0 +1,113 @@
+---
+layout: layouts/case-study.njk
+title: Knowledge Graph Engine - Company Knowledge as a Graph for AI Agents
+description: Architected a hexagonal Effect-TS pipeline that extracts a Postgres-backed knowledge graph from company documents and serves it to AI agents over MCP.
+company: Digital Science
+tags:
+  - Knowledge Graphs
+  - Effect-TS
+  - LLMs
+heroImage: /assets/images/knowledge-graph-engine-hero.png
+permalink: /work/knowledge-graph-engine/
+passwordProtected: true
+contentStyle: technical
+---
+
+## Overview
+
+The Knowledge Graph Engine turns a company's scattered documentation into a queryable knowledge graph that AI agents can reason over. Instead of pointing a language model at a pile of raw documents and hoping retrieval surfaces the right passage, the engine extracts entities and relationships into a Postgres-backed graph and exposes it to agents over the Model Context Protocol (MCP).
+
+The result is a single, structured source of truth about how the company's people, projects, systems, and concepts relate to one another — one that agents can traverse rather than merely search.
+
+## Problem Statement
+
+Institutional knowledge lives in documents that were never designed to be read by machines: wikis, design docs, runbooks, meeting notes, and READMEs. When an AI agent needs to answer a question that spans several of these sources, plain vector retrieval struggles:
+
+- Facts are scattered across documents with no explicit links between them
+- Multi-hop questions ("which services does the team that owns X depend on?") require reasoning over relationships, not just similarity
+- Retrieval returns passages, not structured facts, leaving the model to re-derive connections on every call
+- There is no stable, inspectable representation of what the company actually knows
+
+## Solution Overview
+
+The engine addresses this by building an explicit knowledge graph as a first-class artifact:
+
+1. **Ingests company documents** from their source systems
+2. **Extracts entities and relationships** using LLM-driven extraction against a defined schema
+3. **Persists the graph** in Postgres, with nodes and typed edges
+4. **Reconciles and deduplicates** entities so the same concept is not represented twice
+5. **Serves the graph to AI agents over MCP**, letting them query and traverse it as a tool
+
+Agents no longer receive a bag of text chunks — they get a navigable graph they can walk to answer relational questions.
+
+## Technical Architecture
+
+### Hexagonal Design
+
+The pipeline is built around a hexagonal (ports and adapters) architecture. The extraction and graph-building domain logic sits at the core, isolated from infrastructure concerns. Ports define the contracts for document sources, LLM providers, and graph persistence; adapters implement them. This keeps the core testable and makes it straightforward to swap a document source or model provider without touching the extraction logic.
+
+### Effect-TS Pipeline
+
+The pipeline is implemented in [Effect-TS](https://effect.website/), which provides typed error handling, structured concurrency, and composable effects. Each stage — ingestion, extraction, reconciliation, persistence — is an Effect that can be composed, retried, and observed. This gives the pipeline predictable failure behaviour and makes concurrency across many documents safe by construction.
+
+### Technology Stack
+
+- **Language / Runtime**: TypeScript with Effect-TS
+- **Architecture**: Hexagonal (ports and adapters)
+- **Graph Store**: PostgreSQL
+- **Extraction**: LLM-driven entity and relationship extraction
+- **Agent Interface**: Model Context Protocol (MCP) server
+
+### Architecture Flow
+
+1. **Document Sources**: Adapters pull documents from company systems
+2. **Extraction Core**: LLMs extract entities and typed relationships against the graph schema
+3. **Reconciliation**: Entities are matched and deduplicated to keep the graph coherent
+4. **Graph Persistence**: Nodes and edges are written to Postgres
+5. **MCP Server**: Exposes the graph to AI agents for querying and traversal
+
+## Challenges and Solutions
+
+### Entity Reconciliation
+
+**Challenge**: The same person, service, or concept is referred to differently across documents, producing duplicate nodes.
+
+**Solution**: Added a reconciliation stage that matches candidate entities before persistence, collapsing duplicates into single canonical nodes so the graph stays coherent as more documents are ingested.
+
+### Reliable Extraction at Scale
+
+**Challenge**: LLM extraction is inherently fallible, and running it across a large document corpus multiplies the chances of partial failure.
+
+**Solution**: Modelled every stage as an Effect with typed errors and retries, so a failure on one document does not sink the run, and structured concurrency keeps throughput high without unbounded parallelism.
+
+### Serving a Graph to Agents
+
+**Challenge**: Agents need to traverse relationships, not just fetch documents.
+
+**Solution**: Exposed the graph through an MCP server with tools tailored to graph traversal, letting agents follow edges and answer multi-hop questions natively.
+
+## Impact and Results
+
+### Structured Institutional Knowledge
+Company knowledge becomes an explicit, inspectable graph rather than an opaque pile of documents.
+
+### Multi-hop Reasoning
+Agents can answer relational questions that plain retrieval cannot, by traversing typed edges in the graph.
+
+### Clean Separation of Concerns
+The hexagonal design keeps extraction logic independent of document sources and model providers, making the system adaptable.
+
+### Agent-native Access
+MCP makes the graph a first-class tool for any compatible AI agent, without bespoke integration work.
+
+## Key Achievements
+
+- **Designed a hexagonal architecture** that isolates extraction logic from infrastructure
+- **Built the pipeline in Effect-TS** for typed errors, retries, and safe concurrency
+- **Extracted a Postgres-backed knowledge graph** from unstructured company documents
+- **Implemented entity reconciliation** to keep the graph coherent at scale
+- **Served the graph to AI agents over MCP** for native graph traversal
+
+## Conclusion
+
+The Knowledge Graph Engine demonstrates a durable pattern for grounding AI agents in institutional knowledge: extract structure once, persist it as a graph, and let agents reason over relationships instead of re-deriving them on every query. The combination of a hexagonal architecture and an Effect-TS pipeline yields a system that is testable, resilient, and adaptable as document sources and models evolve.

--- a/src/work/repo-atlas-catalogue.md
+++ b/src/work/repo-atlas-catalogue.md
@@ -1,0 +1,123 @@
+---
+layout: layouts/case-study.njk
+title: Repo Atlas - Making 1,000+ Repos Discoverable with LLMs
+description: Built an LLM-powered catalogue that scans an entire GitHub org and answers "does a repo already exist that does X?" through an MCP server and web UI.
+company: Digital Science
+tags:
+  - LLMs
+  - MCP
+  - TypeScript
+heroImage: /assets/images/repo-atlas-hero.png
+permalink: /work/repo-atlas-catalogue/
+passwordProtected: true
+contentStyle: technical
+---
+
+## Overview
+
+Repo Atlas is an LLM-powered catalogue that makes a sprawling GitHub organisation — over a thousand repositories — actually discoverable. It scans every repo, summarises what each one does, and lets engineers ask the question that large organisations struggle to answer: *"Does a repo already exist that does X?"* Answers are served both through an MCP server, so AI agents can query the catalogue directly, and through a web UI for people.
+
+The goal is to stop teams from rebuilding what already exists, and to make an unmanageably large codebase navigable by intent rather than by remembering repo names.
+
+## Problem Statement
+
+Once an organisation crosses a few hundred repositories, nobody holds the whole map in their head. GitHub search matches on names and code, not on purpose, so:
+
+- Engineers reinvent tools that already exist somewhere in the org
+- Onboarding is slow because there is no way to explore the codebase by what things *do*
+- Institutional knowledge about which repo owns which capability lives only in a few people's heads
+- Naming conventions are inconsistent, so keyword search misses relevant repos entirely
+
+## Solution Overview
+
+Repo Atlas builds a searchable, intent-level catalogue of the entire org:
+
+1. **Scans every repository** in the GitHub organisation
+2. **Summarises each repo** with an LLM, capturing what it does and the capabilities it provides
+3. **Indexes the catalogue** for retrieval by natural-language intent
+4. **Answers "does a repo already exist that does X?"** rather than matching on names
+5. **Serves results over both an MCP server and a web UI**, for agents and humans alike
+
+Instead of guessing repo names, users describe the capability they need and Repo Atlas surfaces the repositories that already provide it.
+
+## Technical Architecture
+
+### Technology Stack
+
+- **Language / Runtime**: TypeScript
+- **Summarisation**: LLM-driven repository analysis
+- **Source**: GitHub organisation-wide scanning
+- **Agent Interface**: Model Context Protocol (MCP) server
+- **Human Interface**: Web UI
+
+### Key Components
+
+#### Org Scanner
+
+Walks the GitHub organisation and gathers the signal needed to describe each repository — READMEs, structure, and metadata — as input for summarisation. Designed to handle 1,000+ repos without manual curation.
+
+#### LLM Summariser
+
+Turns each repository into a concise, capability-focused description. This is what shifts discovery from *name matching* to *intent matching*: the catalogue knows what a repo does, not just what it is called.
+
+#### Catalogue Index
+
+Stores the summaries and makes them retrievable by natural-language query, so a description of a needed capability can be matched against what already exists.
+
+#### Dual Interface: MCP + Web UI
+
+The same catalogue is exposed two ways — an MCP server so AI agents can ask the catalogue questions as a tool, and a web UI so engineers can browse and search directly.
+
+### Architecture Flow
+
+1. **Scan**: Enumerate repositories across the organisation
+2. **Summarise**: Generate an intent-level description of each repo with an LLM
+3. **Index**: Store summaries for natural-language retrieval
+4. **Query**: Users or agents ask whether a capability already exists
+5. **Serve**: Return matching repositories via MCP or the web UI
+
+## Challenges and Solutions
+
+### Scale
+
+**Challenge**: Summarising and keeping over a thousand repositories catalogued without manual effort.
+
+**Solution**: Automated the full scan-and-summarise pipeline so the catalogue covers the whole org and can be refreshed as repositories change.
+
+### Discovery by Intent, Not Name
+
+**Challenge**: Keyword and code search miss relevant repos because they match tokens, not purpose.
+
+**Solution**: Used LLM summaries to describe each repo by capability, so queries phrased as intent ("something that does X") match the right repositories regardless of naming.
+
+### Serving Both Agents and People
+
+**Challenge**: AI agents and human engineers need the catalogue in very different shapes.
+
+**Solution**: Exposed one catalogue through two interfaces — an MCP server for agents and a web UI for humans — so both consume the same source of truth.
+
+## Impact and Results
+
+### Less Duplicated Work
+Engineers can check whether a capability already exists before building it, cutting redundant projects.
+
+### Faster Onboarding
+Newcomers can explore a huge codebase by what things do, not by memorising repo names.
+
+### Agent-native Discovery
+AI agents can query the catalogue over MCP, making org-wide repo discovery part of automated workflows.
+
+### Intent-level Search
+Discovery works on purpose rather than keywords, surfacing relevant repos that name-based search would miss.
+
+## Key Achievements
+
+- **Catalogued 1,000+ repositories** across a GitHub organisation automatically
+- **Built an LLM summarisation pipeline** that describes repos by capability, not name
+- **Enabled intent-level discovery** — "does a repo already exist that does X?"
+- **Exposed the catalogue over MCP** for AI agents and a **web UI** for engineers
+- **Implemented the system in TypeScript** end to end
+
+## Conclusion
+
+Repo Atlas shows how LLMs can make a large codebase legible: by summarising every repository into intent-level descriptions and serving them to both agents and people, it turns an unmanageable sprawl of repos into a catalogue you can actually query. The dual MCP-and-web-UI design means the same knowledge powers automated agent workflows and everyday engineer discovery alike.


### PR DESCRIPTION
## Summary

Adds two new portfolio case studies documenting recent work at: a knowledge graph engine for grounding AI agents in company knowledge, and Repo Atlas, an LLM-powered catalogue for discovering repositories across a large GitHub organisation.

## Changes

- **Knowledge Graph Engine** (`src/work/knowledge-graph-engine.md`): Documents a hexagonal Effect-TS pipeline that extracts a Postgres-backed knowledge graph from company documents and exposes it to AI agents over MCP. Covers the architecture, entity reconciliation challenges, and impact on multi-hop reasoning for agents.

- **Repo Atlas** (`src/work/repo-atlas-catalogue.md`): Documents an LLM-powered catalogue system that scans 1,000+ repositories in a GitHub organisation, summarises them by capability (not name), and serves discovery through both an MCP server and web UI.

- **Portfolio metadata** (`src/_data/work.js`): Registers both case studies in the work grid with metadata (company, description, tags, featured status, grid layout).

## Implementation Details

Both case studies follow the established pattern:
- Frontmatter with layout, title, description, company, tags, hero image, and permalink
- Structured sections: Overview, Problem Statement, Solution Overview, Technical Architecture, Challenges and Solutions, Impact and Results, Key Achievements, and Conclusion
- Tagged with relevant technologies (LLMs, MCP, TypeScript, Effect-TS, Knowledge Graphs)
- Marked as featured with `col-span-2 row-span-1` grid layout for prominence on the work page
- Password-protected flag set for sensitive content

Both entries are marked `status: "published"` and will appear in the work grid and individual case study pages.

https://claude.ai/code/session_01M7TMWWWtUccLsx8Uh6ft1r