### PR TITLE
feat: board-API job sources (Google, Elicit, +9 more)

### DIFF
--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -36,7 +36,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Total subagents spawned (Mode 1) | 3 |
 | Career pages fetched **in a browser** per agent | 5 |
 | Board API calls (`fetch-board.sh ashby\|greenhouse\|lever`) | **unlimited — one curl each; never skip one to save budget** |
-| Google Careers keyword queries (`fetch-board.sh google`) | 2 per run |
+| Google Careers keyword queries (`fetch-board.sh google`) | 3 per run — one of which is always the `DeepMind` London query |
 
 If limits are reached before finding enough matches, report what was found and note the cap was hit.
 
@@ -176,7 +176,7 @@ Budget: max 5 **browser** career page fetches + LinkedIn browser search. Board A
 
    **Do not browser-scrape openai.com or anthropic.com career pages** — these boards supersede them.
 
-0b. **Google Careers** (max 2 keyword queries, never a bare location dump — it returns mostly Cloud sales):
+0b. **Google Careers** (max 3 keyword queries — the two below plus the mandatory `DeepMind` one; never a bare location dump, it returns mostly Cloud sales):
    ```bash
    bash $S google "machine learning" "Berlin Germany"
    bash $S google "research infrastructure" "Germany"
@@ -319,8 +319,10 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 ## Mode 2: Company Search
 
-1. **Check `references/job-sources.md` for a board slug first.** If the company is listed, `bash scripts/fetch-board.sh <ats> <board>` returns the whole board with dates — skip steps 1–2 entirely. If it isn't listed, probe the obvious slug against all three ATSes before falling back to a browser:
+1. **Check `references/job-sources.md` for a board slug first.** If the company is listed, one `fetch-board.sh` call returns the whole board with dates — skip steps 1–2 entirely. If it isn't listed, probe the obvious slug against all three ATSes before falling back to a browser:
    ```bash
+   S=.claude/skills/find-kristian-jobs/scripts/fetch-board.sh   # paths are relative to the repo root
+   bash $S <ats> <slug>                                          # if already listed
    for ats in ashby greenhouse lever; do bash $S $ats <slug> | jq -c '{ats,count,error}'; done
    ```
    Add any new working slug to `references/job-sources.md`.

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -21,7 +21,7 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Script | Purpose |
 |--------|---------|
 | `scripts/fetch-board.sh <ats> <board>` | List an **entire company job board** in one call: `{ats, board, count, jobs[]}` with `posted_date` per role. `ats` = `ashby` \| `greenhouse` \| `lever` \| `google`. Board slugs are in `references/job-sources.md`. Google mode takes a query + location instead of a slug. Free — not counted against the career-page budget. |
-| `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Ashby API → Jina Reader → plain curl. |
+| `scripts/fetch-job.sh <url> [<url> ...]` | Fetch job postings and return `{url, posted_date, status, content}` JSON — an object for one URL, an array (in argument order) for several. Auto-selects: Greenhouse API → Lever API → Ashby single-posting API → Jina Reader → plain curl. **Pass the whole shortlist in one call** — it fetches them concurrently (~4x faster than a shell loop); `--jobs N` tunes parallelism, default 6. |
 | `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON. Structured questions via Greenhouse/Workable/Ashby public APIs; apply-page scraping for Lever/generic. When `needs_browser: true` the form wasn't captured — open `apply_url` with browser tools. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Claude in `bypassPermissions` mode and sends a push notification when done. |
 
@@ -102,7 +102,12 @@ STATUS=$(echo "$RESULT"     | jq -r '.status')          # "open", "closed", or "
 CONTENT=$(echo "$RESULT"    | jq -r '.content')
 ```
 
-The script auto-selects the best source: **Greenhouse API → Lever API → Jina Reader → plain curl**. Always preferred over raw `curl` or `WebFetch`.
+The script auto-selects the best source: **Greenhouse API → Lever API → Ashby single-posting API → Jina Reader → plain curl**. Always preferred over raw `curl` or `WebFetch`.
+
+**Fetching more than one posting? Pass them all to a single call** — it fetches concurrently and returns an array in argument order, instead of paying each round-trip serially:
+```bash
+bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "$URL_A" "$URL_B" "$URL_C" | jq -r '.[] | "\(.posted_date) \(.status) \(.url)"'
+```
 
 ## Output
 
@@ -175,8 +180,11 @@ Budget: max 5 **browser** career page fetches + LinkedIn browser search. Board A
    ```bash
    bash $S google "machine learning" "Berlin Germany"
    bash $S google "research infrastructure" "Germany"
+   bash $S google "DeepMind" "London UK"
    ```
-   Results carry `posted_date: unknown` by design (Google publishes none) and are ordered newest-first. Keep them; the freshness override in this skill exempts Google. Google DeepMind roles are on the `deepmind` Greenhouse board, not here.
+   Results carry `posted_date: unknown` by design (Google publishes none) and are ordered newest-first. Keep them; the freshness override in this skill exempts Google.
+
+   **Google DeepMind needs BOTH sources — sweep each:** the `deepmind` Greenhouse board carries only US roles (Mountain View / NYC / Seattle), and DeepMind's **London** roles are on Google Careers, reachable only via the `DeepMind` keyword query above. Skipping either one silently drops half of a Tier 1 company. See `references/job-sources.md` §2.
 
 1. Use `mcp__claude-in-chrome__navigate` to open each **remaining** career page (companies with no board API), then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://holtzbrinck.com/en/jobs`
@@ -238,13 +246,14 @@ Collect all results from the 3 agents. Deduplicate by URL. If total > 20, keep t
 4. If the date is unknown, proceed to parse — but flag `posted_date: unknown`. **Exception: Google roles keep full priority despite an unknown date** (see Source-specific overrides).
 5. Apply the **geography pre-filter** — drop US-only / US-timezone-remote roles before spending a fetch on them.
 
-For each surviving posting, fetch the full content:
+Fetch the full content of all surviving postings in **one batched call** — not a loop. The batch runs concurrently and returns an array in argument order:
 ```bash
-RESULT=$(bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "$JOB_URL")
-POSTED_DATE=$(echo "$RESULT" | jq -r '.posted_date')
-STATUS=$(echo "$RESULT"     | jq -r '.status')
-CONTENT=$(echo "$RESULT"    | jq -r '.content')
+RESULTS=$(bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "${JOB_URLS[@]}")
+echo "$RESULTS" | jq -r '.[] | "\(.posted_date) | \(.status) | \(.url)"'
+# one posting's body:
+echo "$RESULTS" | jq -r '.[0].content'
 ```
+A serial loop pays every network round-trip end to end; the batch finishes in about the time of its slowest posting (measured ~4x faster on a 6-URL shortlist).
 
 After fetching, re-apply the freshness filter using the returned `posted_date` and `status` fields:
 - Look for fields: `Posted`, `Date posted`, `Listed`, `Apply by`, `Closes`, `Deadline`.

--- a/.claude/skills/find-kristian-jobs/SKILL.md
+++ b/.claude/skills/find-kristian-jobs/SKILL.md
@@ -12,6 +12,7 @@ You are a job search agent for **Kristian Garza**, a Senior AI Engineer at Digit
 Before proceeding, read these reference files for full context:
 - `references/kristian-profile.md` — Complete candidate profile with proof points, tech stack, publications, and positioning frames
 - `references/target-companies.md` — Curated target company list across three tiers
+- `references/job-sources.md` — Which sources to sweep and the cheapest correct way to read each (board API slugs, Google/Jina, browser, WebSearch)
 
 ## Scripts
 
@@ -19,7 +20,8 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 
 | Script | Purpose |
 |--------|---------|
-| `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Jina Reader → plain curl. |
+| `scripts/fetch-board.sh <ats> <board>` | List an **entire company job board** in one call: `{ats, board, count, jobs[]}` with `posted_date` per role. `ats` = `ashby` \| `greenhouse` \| `lever` \| `google`. Board slugs are in `references/job-sources.md`. Google mode takes a query + location instead of a slug. Free — not counted against the career-page budget. |
+| `scripts/fetch-job.sh <url>` | Fetch a job posting and return `{url, posted_date, status, content}` JSON. Auto-selects: Greenhouse API → Lever API → Ashby API → Jina Reader → plain curl. |
 | `scripts/fetch-application-form.sh <url>` | Find the **apply deep link** and extract the actual application form questions. Returns `{url, ats, apply_url, source, needs_browser, questions, form_text}` JSON. Structured questions via Greenhouse/Workable/Ashby public APIs; apply-page scraping for Lever/generic. When `needs_browser: true` the form wasn't captured — open `apply_url` with browser tools. |
 | `scripts/run-job-search.sh` | Run a full unattended search (cron/remote trigger). Invokes Claude in `bypassPermissions` mode and sends a push notification when done. |
 
@@ -32,7 +34,9 @@ Bundled helper scripts live in the `scripts/` subfolder of this skill:
 | Total WebSearch queries (across all agents) | 15 |
 | Total job postings fetched & parsed | 20 |
 | Total subagents spawned (Mode 1) | 3 |
-| Career pages fetched per agent | 5 |
+| Career pages fetched **in a browser** per agent | 5 |
+| Board API calls (`fetch-board.sh ashby\|greenhouse\|lever`) | **unlimited — one curl each; never skip one to save budget** |
+| Google Careers keyword queries (`fetch-board.sh google`) | 2 per run |
 
 If limits are reached before finding enough matches, report what was found and note the cap was hit.
 
@@ -48,12 +52,29 @@ If limits are reached before finding enough matches, report what was found and n
 
 When parsing a posting with Jina Reader, always look for: `Posted`, `Date posted`, `Listed`, `Apply by`, `Closes`, or any timestamp field. If the posting date cannot be determined, flag it as **date unknown** and deprioritize — do not include it in scored results unless it is the only option for a strong domain match.
 
+### Source-specific overrides
+
+| Source | Override |
+|--------|----------|
+| **Ashby** boards | `publishedAt` is a true publish date — apply the 5-month rule strictly. Also discard `isListed: false`. Ashby boards keep **zombie postings**: still listed, published years ago (Elicit lists a 2021 ML Engineer role). The date rule catches these; don't trust `listed` alone. |
+| **Greenhouse** boards | Only `updated_at` is exposed. Read it as "not older than" — a role can be older than its `updated_at` but never newer. Don't treat it as a publish date when reporting. |
+| **Google Careers** | **Google publishes no date anywhere** — not on the results page, not on the posting. The blanket "deprioritize unknown dates" rule would silently kill every Google role, so it does **not** apply here. Instead: `fetch-board.sh google` requests `sort_by=date`, so treat the returned order as the freshness proxy, take the top results, and score them normally with `posted_date: unknown (Google — no date published)`. |
+
+### Geography pre-filter
+
+Run this **before** fetching a posting's full content, so budget isn't spent on roles that can't score:
+
+- **Discard** US-only roles and US-timezone-locked remote roles (e.g. "Oakland, CA (or remote within US timezones)"). Work arrangement is 15% of the score and these cap out around 60%.
+- **Keep** anything mentioning EMEA, Europe, Germany, Berlin, "remote (global)", or a European secondary location.
+- Report what the filter dropped per company — never silently drop an entire employer.
+
 ## Tool Stack
 
 | Task | Tool |
 |------|------|
 | Search for jobs | `WebSearch` |
-| Fetch career pages (JS-heavy) | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` |
+| **List a whole company board (preferred)** | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh <ats> <board>` — slugs in `references/job-sources.md` |
+| Fetch career pages (JS-heavy, **only when no board API exists**) | `mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text` |
 | Search LinkedIn Jobs (authenticated) | `mcp__claude-in-chrome__*` browser tools |
 | Parse job posting content | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-job.sh "[url]"` |
 | Fetch application form + questions | `Bash`: `bash .claude/skills/find-kristian-jobs/scripts/fetch-application-form.sh "[url]"` |
@@ -132,13 +153,32 @@ leads/
 
 ---
 
-**Agent 1 — Direct Career Pages + LinkedIn Browser**
+**Agent 1 — Board APIs + Google + Career Pages + LinkedIn Browser**
 
-Budget: max 5 career page fetches + LinkedIn browser search.
+Budget: max 5 **browser** career page fetches + LinkedIn browser search. Board API calls are free and don't count.
 
-1. Use `mcp__claude-in-chrome__navigate` to open each career page, then `mcp__claude-in-chrome__get_page_text` to extract roles:
-   - `https://openai.com/careers/search/`
-   - `https://www.anthropic.com/careers/jobs`
+0. **Sweep the board APIs first.** Read `references/job-sources.md` for the slug table, then run one call per company — these return every open role with a real posted date and cost nothing:
+   ```bash
+   S=.claude/skills/find-kristian-jobs/scripts/fetch-board.sh
+   bash $S ashby openai;      bash $S greenhouse anthropic
+   bash $S greenhouse deepmind; bash $S ashby cohere
+   bash $S ashby elicit;      bash $S greenhouse chanzuckerberginitiative
+   bash $S ashby langchain;   bash $S ashby notion
+   bash $S ashby replit;      bash $S greenhouse vercel
+   bash $S greenhouse elsevier
+   ```
+   Boards are large (OpenAI ~740, Anthropic ~400) — filter titles/locations in `jq` before returning anything. Apply the geography pre-filter and the 5-month rule to `posted_date` here, not later.
+
+   **Do not browser-scrape openai.com or anthropic.com career pages** — these boards supersede them.
+
+0b. **Google Careers** (max 2 keyword queries, never a bare location dump — it returns mostly Cloud sales):
+   ```bash
+   bash $S google "machine learning" "Berlin Germany"
+   bash $S google "research infrastructure" "Germany"
+   ```
+   Results carry `posted_date: unknown` by design (Google publishes none) and are ordered newest-first. Keep them; the freshness override in this skill exempts Google. Google DeepMind roles are on the `deepmind` Greenhouse board, not here.
+
+1. Use `mcp__claude-in-chrome__navigate` to open each **remaining** career page (companies with no board API), then `mcp__claude-in-chrome__get_page_text` to extract roles:
    - `https://holtzbrinck.com/en/jobs`
    - `https://careers.merantix-aicampus.com/jobs?filter=eyJzZWFyY2hhYmxlX2xvY2F0aW9ucyI6WyJCZXJsaW4sIEdlcm1hbnkiXX0%3D` (Merantix AI Campus network, Berlin-filtered — covers Merantix Momentum and portfolio companies)
    - On each career page, check for a "posted date" or "last updated" field; skip any role posted more than 5 months ago or marked closed.
@@ -194,8 +234,9 @@ Collect all results from the 3 agents. Deduplicate by URL. If total > 20, keep t
 **Freshness filter — run before parsing:**
 1. For each posting, check any date metadata already returned (LinkedIn `f_TPR` filter, search snippet dates, `posted_date` from agents).
 2. Discard postings with a known date older than **5 months** from today.
-3. Discard postings explicitly marked closed/filled.
-4. If the date is unknown, proceed to parse — but flag `posted_date: unknown`.
+3. Discard postings explicitly marked closed/filled, and Ashby postings with `listed: false`.
+4. If the date is unknown, proceed to parse — but flag `posted_date: unknown`. **Exception: Google roles keep full priority despite an unknown date** (see Source-specific overrides).
+5. Apply the **geography pre-filter** — drop US-only / US-timezone-remote roles before spending a fetch on them.
 
 For each surviving posting, fetch the full content:
 ```bash
@@ -269,8 +310,12 @@ This runs the full contact workflow: scrape company site, search LinkedIn, class
 
 ## Mode 2: Company Search
 
-1. Search `[company] careers engineering 2026` and `[company] jobs AI ML 2026`
-2. Fetch career page via browser (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) or Jina Reader as fallback
+1. **Check `references/job-sources.md` for a board slug first.** If the company is listed, `bash scripts/fetch-board.sh <ats> <board>` returns the whole board with dates — skip steps 1–2 entirely. If it isn't listed, probe the obvious slug against all three ATSes before falling back to a browser:
+   ```bash
+   for ats in ashby greenhouse lever; do bash $S $ats <slug> | jq -c '{ats,count,error}'; done
+   ```
+   Add any new working slug to `references/job-sources.md`.
+2. Otherwise: search `[company] careers engineering 2026`, then fetch the career page via browser (`mcp__claude-in-chrome__navigate` + `mcp__claude-in-chrome__get_page_text`) or Jina Reader as fallback
 3. **Apply freshness filter:** discard any role marked closed/filled or with a posted date older than 5 months. Flag roles with no visible date as `posted_date: unknown`.
 4. List only open, recent roles in a table with `URL` and `Posted` columns (clickable markdown links)
 5. Score each using the multi-dimensional matrix

--- a/.claude/skills/find-kristian-jobs/references/job-sources.md
+++ b/.claude/skills/find-kristian-jobs/references/job-sources.md
@@ -1,0 +1,94 @@
+# Job Sources Registry
+
+Every source the search is allowed to sweep, and the cheapest correct way to read it.
+
+**Rule: if a company appears in the Board API table below, never browser-scrape its career page.** One `fetch-board.sh` call returns the whole board as JSON with dates. Browser fetches are budget-capped; board API calls are not.
+
+---
+
+## 1. Board APIs (free, structured, dated) — preferred
+
+```bash
+bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh <ats> <board>
+```
+
+Returns `{ats, board, count, jobs: [{title, location, posted_date, url, apply_url, remote, listed, department}]}`.
+
+| Company | Tier | ATS | Board slug | Roles (verified 2026-07-24) |
+|---------|------|-----|-----------|------|
+| **OpenAI** | 1 | ashby | `openai` | 741 |
+| **Anthropic** | 1 | greenhouse | `anthropic` | 407 |
+| **Google DeepMind** | 1 | greenhouse | `deepmind` | 10 |
+| **Cohere** | 1 | ashby | `cohere` | 137 |
+| **Notion** | 3 | ashby | `notion` | 139 |
+| **Replit** | 3 | ashby | `replit` | 92 |
+| **LangChain** | 3 | ashby | `langchain` | 85 |
+| **Vercel** | 3 | greenhouse | `vercel` | 80 |
+| **Elicit** | 3 | ashby | `elicit` | 11 |
+| **Chan Zuckerberg Initiative** | 2 | greenhouse | `chanzuckerberginitiative` | 11 |
+| **Elsevier / RELX** | 3 | greenhouse | `elsevier` | 9 |
+
+Data quality by ATS — matters for the freshness filter:
+
+| ATS | Date field | Trust | Delisting signal |
+|-----|-----------|-------|------------------|
+| **ashby** | `publishedAt` — true publish timestamp | **high** — filter on it directly | `isListed: false` → treat as closed |
+| **greenhouse** | `updated_at` — proxy only | medium — read as "not older than" | none; job absent from board = gone |
+| **lever** | `createdAt` — true creation time | high | none |
+
+Ashby boards carry **zombie postings**: `isListed: true` with a `publishedAt` from years back (Elicit still lists a 2021 ML Engineer role). Always apply the 5-month rule to `posted_date` even when `listed` is true.
+
+**No board API found** (browser or WebSearch only): Mistral AI, Hugging Face, Weights & Biases, Allen Institute / Semantic Scholar, Crossref, ORCID, OpenAlex, Springer Nature, Protocol Labs, Wellcome, EMBL-EBI, CERN, Holtzbrinck. Slug guesses were probed and all 404'd — don't burn budget re-probing; use a browser or WebSearch for these.
+
+To test a new company cheaply, try the slug against all three ATSes before adding it here:
+```bash
+for ats in ashby greenhouse lever; do
+  bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh $ats <slug> | jq -c '{ats,count,error}'
+done
+```
+
+---
+
+## 2. Google Careers (Jina-rendered, undated)
+
+Google has **no public jobs API** — `/about/careers/applications/api/v3/search/` and `careers.google.com/api/v3/` both return 404, and the results page is a client-rendered JS app whose raw HTML contains no listings. Jina Reader executes it, so:
+
+```bash
+bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh google "machine learning" "Berlin Germany"
+```
+
+**Always search by keyword, never dump a bare location.** The unfiltered Berlin list returns ~13 roles that are almost entirely Cloud sales, customer engineering and DACH account management — one keyword query cut it to the single relevant hit (AI Infrastructure Engineer). Suggested queries, 2 per run maximum:
+
+- `"machine learning"` + `Berlin Germany`
+- `"research infrastructure"` + `Germany`
+- `"knowledge graph"` + `Germany`
+
+Google DeepMind roles are **not** in this feed — they live on the `deepmind` Greenhouse board above.
+
+**Google publishes no posted date anywhere** — not on the results page, not on the posting. `fetch-board.sh google` always returns `posted_date: "unknown"` and requests `sort_by=date`, so the returned order is newest-first. See the freshness exemption in SKILL.md.
+
+---
+
+## 3. Browser sources (budget-capped)
+
+Only for companies with no board API:
+
+- `https://holtzbrinck.com/en/jobs`
+- LinkedIn Jobs, authenticated, `f_TPR=r12960000` (past ~150 days)
+- Any Tier 2/3 career page from `target-companies.md` not listed in section 1
+
+---
+
+## 4. WebSearch
+
+Track A (AI labs) and Track B (research infrastructure) query sets in SKILL.md. Keep for discovering companies **not** on the target list — it is the only source that finds unknown employers. Board APIs cover the known ones far more cheaply, so don't spend WebSearch queries re-finding OpenAI or Anthropic roles.
+
+---
+
+## Geography pre-filter
+
+Apply **before** fetching a posting's full content, not after scoring:
+
+- Discard roles whose location is US-only or a US-timezone remote requirement (e.g. Elicit's "Oakland, CA (or remote within US timezones)") — work arrangement is 15% of the score and these top out around 60%, so fetching them wastes budget.
+- **Keep** anything saying EMEA, Europe, Germany, Berlin, "remote (global)", or listing a European secondary location.
+- Elicit is the standing example: strong domain fit, all engineering roles US-timezone-locked. Sweep it anyway — it has opened EMEA-remote roles before — but expect most runs to filter everything out. Note it in the run report rather than silently dropping the company.

--- a/.claude/skills/find-kristian-jobs/references/job-sources.md
+++ b/.claude/skills/find-kristian-jobs/references/job-sources.md
@@ -18,7 +18,7 @@ Returns `{ats, board, count, jobs: [{title, location, posted_date, url, apply_ur
 |---------|------|-----|-----------|------|
 | **OpenAI** | 1 | ashby | `openai` | 741 |
 | **Anthropic** | 1 | greenhouse | `anthropic` | 407 |
-| **Google DeepMind** | 1 | greenhouse | `deepmind` | 10 |
+| **Google DeepMind** (US only — London is on Google Careers, see §2) | 1 | greenhouse | `deepmind` | 10 |
 | **Cohere** | 1 | ashby | `cohere` | 137 |
 | **Notion** | 3 | ashby | `notion` | 139 |
 | **Replit** | 3 | ashby | `replit` | 92 |

--- a/.claude/skills/find-kristian-jobs/references/job-sources.md
+++ b/.claude/skills/find-kristian-jobs/references/job-sources.md
@@ -27,6 +27,38 @@ Returns `{ats, board, count, jobs: [{title, location, posted_date, url, apply_ur
 | **Elicit** | 3 | ashby | `elicit` | 11 |
 | **Chan Zuckerberg Initiative** | 2 | greenhouse | `chanzuckerberginitiative` | 11 |
 | **Elsevier / RELX** | 3 | greenhouse | `elsevier` | 9 |
+| **Perplexity** | 1 | ashby | `perplexity` | 85 |
+| **Faculty AI** (London) | 2 | ashby | `faculty` | 66 |
+| **DeepL** | 2 | ashby | `deepl` | 36 |
+| **Isomorphic Labs** | 2 | greenhouse | `isomorphiclabs` | 20 |
+| **Quantexa** | 3 | ashby | `quantexa` | 30 |
+| **Speechmatics** | 3 | greenhouse | `speechmatics` | 10 |
+| **PolyAI** | 3 | greenhouse | `polyai` | 15 |
+| **Wayve** | 3 | ashby *or* greenhouse | `wayve` | 118 / 120 |
+| **Graphcore** | 3 | greenhouse | `graphcore` | 217 |
+| **Helsing** (defence — values call) | 3 | greenhouse | `helsing` | 122 |
+| **Celonis** (Munich HQ) | 3 | greenhouse | `celonis` | 226 |
+| **Databricks** | 3 | greenhouse | `databricks` | 794 |
+| **Scale AI** | 3 | greenhouse | `scaleai` | 196 |
+| **Monzo** | 3 | greenhouse | `monzo` | 76 |
+| **ElevenLabs** | 3 | ashby | `elevenlabs` | 211 |
+| **Synthesia** | 3 | ashby | `synthesia` | 76 |
+| **Aleph Alpha** | 3 | ashby | `alephalpha` | 8 |
+| **Black Forest Labs** (Freiburg) | 3 | greenhouse | `blackforestlabs` | 13 |
+| **Stability AI** | 3 | greenhouse | `stabilityai` | 4 |
+| **Cursor / Anysphere** | 3 | ashby | `cursor` | 121 |
+| **Harvey** | 3 | ashby | `harvey` | 342 |
+| **Sierra** | 3 | ashby | `sierra` | 165 |
+| **Lovable** | 3 | ashby *or* greenhouse | `lovable` | 68 / 58 |
+| **Together AI** | 3 | greenhouse | `togetherai` | 58 |
+| **Fireworks AI** | 3 | ashby *or* greenhouse | `fireworksai` | 46 |
+| **n8n** (Berlin) | 3 | ashby | `n8n` | 40 |
+| **Langfuse** | 3 | ashby | `langfuse` | 9 |
+| **Improbable** | 3 | ashby | `improbable` | 9 |
+| **Tractable** | 3 | ashby | `tractable` | 4 |
+| **dunnhumby** | 3 | greenhouse | `dunnhumby` | 72 |
+
+All rows below Elsevier were discovered and verified on 2026-07-24 by the London/Munich run. Some boards resolve on the EU Greenhouse host (`job-boards.eu.greenhouse.io`) — `fetch-board.sh` handles this transparently.
 
 Data quality by ATS — matters for the freshness filter:
 
@@ -39,6 +71,8 @@ Data quality by ATS — matters for the freshness filter:
 Ashby boards carry **zombie postings**: `isListed: true` with a `publishedAt` from years back (Elicit still lists a 2021 ML Engineer role). Always apply the 5-month rule to `posted_date` even when `listed` is true.
 
 **No board API found** (browser or WebSearch only): Mistral AI, Hugging Face, Weights & Biases, Allen Institute / Semantic Scholar, Crossref, ORCID, OpenAlex, Springer Nature, Protocol Labs, Wellcome, EMBL-EBI, CERN, Holtzbrinck. Slug guesses were probed and all 404'd — don't burn budget re-probing; use a browser or WebSearch for these.
+
+Also probed and dead as of 2026-07-24 (do not re-probe): Personio, Snyk, Revolut, Thought Machine, Darktrace, Builder.ai, Glean, Contextual AI, Exscientia, BenevolentAI, Starling Bank, Checkout.com, Anthropic-adjacent slug variants of DeepMind. **Mistral AI**: `lever/mistral` still resolves but now returns `[]` — the board that seeded `leads/pipeline.json` has been emptied or moved, and no Ashby/Greenhouse equivalent exists. Merantix uses its own host, `careers.merantix-aicampus.com`.
 
 To test a new company cheaply, try the slug against all three ATSes before adding it here:
 ```bash
@@ -63,7 +97,13 @@ bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh google "machine le
 - `"research infrastructure"` + `Germany`
 - `"knowledge graph"` + `Germany`
 
-Google DeepMind roles are **not** in this feed — they live on the `deepmind` Greenhouse board above.
+**Google DeepMind London lives HERE, not on the `deepmind` Greenhouse board.** Verified 2026-07-24: the `deepmind` Greenhouse board carries only ~10 US roles (Mountain View / NYC / Seattle). DeepMind's London roles are on Google Careers and are retrieved by using `DeepMind` as the keyword:
+
+```bash
+bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh google "DeepMind" "London UK"
+```
+
+That query returns ~20 London roles, the DeepMind-branded ones being mostly Research Scientist / Research Engineer posts (agent post-training, AGI safety & alignment, tool use, RL, robotics, protein design) plus a fixed-term Production Engineer. Sweep both sources: Greenhouse `deepmind` for US, Google Careers keyword `DeepMind` for London. Munich returns almost nothing DeepMind-related.
 
 **Google publishes no posted date anywhere** — not on the results page, not on the posting. `fetch-board.sh google` always returns `posted_date: "unknown"` and requests `sort_by=date`, so the returned order is newest-first. See the freshness exemption in SKILL.md.
 

--- a/.claude/skills/find-kristian-jobs/references/target-companies.md
+++ b/.claude/skills/find-kristian-jobs/references/target-companies.md
@@ -6,7 +6,8 @@
 |---------|-------------|--------------|-------|
 | **Anthropic** | Mission-driven AI safety, values research rigor | Applied AI, Developer Tools, Research Infrastructure | Kristian's scholarly infrastructure + LLM production experience is rare |
 | **OpenAI** | Frontier LLM development, massive scale | Applied Research, Platform/API, Developer Experience | Side projects (ParrotGPT, SnowyOwl) show deep engagement with OpenAI stack |
-| **Google DeepMind** | Research-to-production pipeline, knowledge systems | Knowledge & Reasoning, Scholar/Academic products, AI Infrastructure | Google Scholar + Dimensions overlap; PID/metadata expertise is unique |
+| **Google DeepMind** | Research-to-production pipeline, knowledge systems | Knowledge & Reasoning, Scholar/Academic products, AI Infrastructure | Google Scholar + Dimensions overlap; PID/metadata expertise is unique. Board: `fetch-board.sh greenhouse deepmind` |
+| **Google (non-DeepMind)** | Berlin office, AI infrastructure roles | AI Infrastructure, Research | No API and no posted dates — `fetch-board.sh google "<keyword>" "Berlin Germany"`. Berlin list is sales-heavy; always search by keyword |
 | **Meta AI (FAIR)** | Open research culture, large-scale systems | FAIR Research, AI Infrastructure, Developer Tools | Open science values alignment, publications record |
 | **Cohere** | Enterprise AI, retrieval-augmented generation | Applied AI, Search & Retrieval | RAG + semantic search maps directly to Query Translation API work |
 | **Mistral AI** | European frontier lab, growing fast | Engineering, Applied AI | Berlin-adjacent (Paris), European AI leadership |
@@ -32,7 +33,7 @@
 
 | Company | Why it fits | Target teams | Notes |
 |---------|-------------|--------------|-------|
-| **Elicit / Ought** | AI-powered research tools | Engineering | LLMs + scholarly domain = core product fit |
+| **Elicit / Ought** | AI-powered research tools | Engineering | LLMs + scholarly domain = core product fit. Board: `fetch-board.sh ashby elicit`. **Caveat:** every engineering role is "Oakland, CA (or remote within US timezones)" — geography knockout. Sweep anyway: they have posted EMEA-remote roles before |
 | **Consensus** | AI-powered academic search | Engineering | Direct overlap with Query Translation API work |
 | **Semantic Scholar (AI2)** | Academic knowledge graph + NLP | Engineering, ML | Publications + NLP pipeline experience |
 | **Weights & Biases** | ML developer tools | Engineering, Product | Developer tools + AI engineering background |

--- a/.claude/skills/find-kristian-jobs/references/target-companies.md
+++ b/.claude/skills/find-kristian-jobs/references/target-companies.md
@@ -6,8 +6,8 @@
 |---------|-------------|--------------|-------|
 | **Anthropic** | Mission-driven AI safety, values research rigor | Applied AI, Developer Tools, Research Infrastructure | Kristian's scholarly infrastructure + LLM production experience is rare |
 | **OpenAI** | Frontier LLM development, massive scale | Applied Research, Platform/API, Developer Experience | Side projects (ParrotGPT, SnowyOwl) show deep engagement with OpenAI stack |
-| **Google DeepMind** | Research-to-production pipeline, knowledge systems | Knowledge & Reasoning, Scholar/Academic products, AI Infrastructure | Google Scholar + Dimensions overlap; PID/metadata expertise is unique. Board: `fetch-board.sh greenhouse deepmind` |
-| **Google (non-DeepMind)** | Berlin office, AI infrastructure roles | AI Infrastructure, Research | No API and no posted dates — `fetch-board.sh google "<keyword>" "Berlin Germany"`. Berlin list is sales-heavy; always search by keyword |
+| **Google DeepMind** | Research-to-production pipeline, knowledge systems | Knowledge & Reasoning, Scholar/Academic products, AI Infrastructure | Google Scholar + Dimensions overlap; PID/metadata expertise is unique. Board: `bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh greenhouse deepmind` |
+| **Google (non-DeepMind)** | Berlin office, AI infrastructure roles | AI Infrastructure, Research | No API and no posted dates — `bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh google "<keyword>" "Berlin Germany"`. Berlin list is sales-heavy; always search by keyword |
 | **Meta AI (FAIR)** | Open research culture, large-scale systems | FAIR Research, AI Infrastructure, Developer Tools | Open science values alignment, publications record |
 | **Cohere** | Enterprise AI, retrieval-augmented generation | Applied AI, Search & Retrieval | RAG + semantic search maps directly to Query Translation API work |
 | **Mistral AI** | European frontier lab, growing fast | Engineering, Applied AI | Berlin-adjacent (Paris), European AI leadership |
@@ -33,7 +33,7 @@
 
 | Company | Why it fits | Target teams | Notes |
 |---------|-------------|--------------|-------|
-| **Elicit / Ought** | AI-powered research tools | Engineering | LLMs + scholarly domain = core product fit. Board: `fetch-board.sh ashby elicit`. **Caveat:** every engineering role is "Oakland, CA (or remote within US timezones)" — geography knockout. Sweep anyway: they have posted EMEA-remote roles before |
+| **Elicit / Ought** | AI-powered research tools | Engineering | LLMs + scholarly domain = core product fit. Board: `bash .claude/skills/find-kristian-jobs/scripts/fetch-board.sh ashby elicit`. **Caveat:** every engineering role is "Oakland, CA (or remote within US timezones)" — geography knockout. Sweep anyway: they have posted EMEA-remote roles before |
 | **Consensus** | AI-powered academic search | Engineering | Direct overlap with Query Translation API work |
 | **Semantic Scholar (AI2)** | Academic knowledge graph + NLP | Engineering, ML | Publications + NLP pipeline experience |
 | **Weights & Biases** | ML developer tools | Engineering, Product | Developer tools + AI engineering background |

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-board.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-board.sh
@@ -23,7 +23,9 @@
 # (Greenhouse only exposes updated_at) and isListed distinguishes live roles from
 # zombie postings that are still reachable by URL.
 #
-# Requires: curl, jq. Optional: JINA_API_KEY (required for google mode).
+# Requires: curl, jq — plus grep, sed and awk, which the google mode uses to harvest
+# posting links out of the rendered page. Optional: JINA_API_KEY (required for google
+# mode; the other modes are pure curl + jq).
 
 set -uo pipefail
 
@@ -47,7 +49,10 @@ emit() {
 }
 
 fail() {
-  echo "{\"ats\": \"$1\", \"board\": \"$2\", \"count\": 0, \"jobs\": [], \"error\": \"$3\"}"
+  # Build with jq, not string interpolation: board can be a Google query string
+  # containing quotes or backslashes, which would emit invalid JSON.
+  jq -n --arg ats "$1" --arg board "$2" --arg error "$3" \
+    '{ats: $ats, board: $board, count: 0, jobs: [], error: $error}'
   exit 0
 }
 
@@ -118,7 +123,7 @@ case "$ATS" in
       title:       .text,
       location:    (.categories.location // ""),
       posted_date: ((.createdAt // 0) | if . == 0 then "unknown"
-                    else (. / 1000 | strftime("%Y-%m-%d")) end),
+                    else (. / 1000 | floor | strftime("%Y-%m-%d")) end),
       url:         .hostedUrl,
       apply_url:   (.applyUrl // .hostedUrl),
       remote:      null,

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-board.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-board.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# fetch-board.sh — List every open role on a company job board in one call.
+#
+# Usage:
+#   ./scripts/fetch-board.sh ashby      <board>            # e.g. elicit
+#   ./scripts/fetch-board.sh greenhouse <board>            # e.g. anthropic
+#   ./scripts/fetch-board.sh lever      <company>
+#   ./scripts/fetch-board.sh google     "<query>" ["<location>"]
+#
+# Output: JSON to stdout
+#   { "ats": "...", "board": "...", "count": N, "jobs": [
+#       { "title": "...", "location": "...", "posted_date": "YYYY-MM-DD|unknown",
+#         "url": "...", "apply_url": "...", "remote": true|false|null,
+#         "listed": true|false|null, "department": "..." } ] }
+#
+# Why this exists: scraping a career page in a browser costs a page fetch from the
+# skill's budget and usually loses the posted date. Ashby/Greenhouse/Lever all expose
+# unauthenticated listing APIs that return every role WITH a real published date, for
+# the price of one curl. Google has no such API — its results page is client-rendered —
+# so the google mode renders it through Jina Reader and harvests the posting links.
+#
+# Ashby is the highest-quality source: publishedAt is the true publish timestamp
+# (Greenhouse only exposes updated_at) and isListed distinguishes live roles from
+# zombie postings that are still reachable by URL.
+#
+# Requires: curl, jq. Optional: JINA_API_KEY (required for google mode).
+
+set -uo pipefail
+
+ATS="${1:-}"
+BOARD="${2:-}"
+EXTRA="${3:-}"
+
+if [[ -z "$ATS" || -z "$BOARD" ]]; then
+  echo '{"error": "Usage: fetch-board.sh <ashby|greenhouse|lever|google> <board|query> [location]"}' >&2
+  exit 1
+fi
+
+JINA_KEY="${JINA_API_KEY:-}"
+TIMEOUT=25
+UA="Mozilla/5.0 (compatible; job-board-fetch/1.0)"
+
+emit() {
+  local ats="$1" board="$2" jobs="$3"
+  jq -n --arg ats "$ats" --arg board "$board" --argjson jobs "$jobs" \
+    '{ats: $ats, board: $board, count: ($jobs | length), jobs: $jobs}'
+}
+
+fail() {
+  echo "{\"ats\": \"$1\", \"board\": \"$2\", \"count\": 0, \"jobs\": [], \"error\": \"$3\"}"
+  exit 0
+}
+
+case "$ATS" in
+
+  # ── Ashby ──────────────────────────────────────────────────────────────────
+  # https://api.ashbyhq.com/posting-api/job-board/{board}
+  # Returns every posting with publishedAt, isListed, location, apply URL and the
+  # full plain-text description — no auth, no pagination.
+  ashby)
+    RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+      "https://api.ashbyhq.com/posting-api/job-board/${BOARD}?includeCompensation=true" 2>/dev/null || echo "")
+
+    if [[ -z "$RESPONSE" ]] || ! jq -e '.jobs' <<<"$RESPONSE" >/dev/null 2>&1; then
+      fail ashby "$BOARD" "board not found or API unreachable"
+    fi
+
+    JOBS=$(jq -c '[.jobs[] | {
+      title:       .title,
+      location:    (.location // ""),
+      posted_date: ((.publishedAt // "") | if . == "" then "unknown" else .[0:10] end),
+      url:         .jobUrl,
+      apply_url:   (.applyUrl // .jobUrl),
+      remote:      (if .workplaceType == "Remote" then true elif .isRemote == true then true else .isRemote end),
+      listed:      .isListed,
+      department:  ((.department // "") + (if (.team // "") == "" then "" else " / " + .team end))
+    }]' <<<"$RESPONSE")
+    emit ashby "$BOARD" "$JOBS"
+    ;;
+
+  # ── Greenhouse ─────────────────────────────────────────────────────────────
+  # https://boards-api.greenhouse.io/v1/boards/{board}/jobs
+  # No true publish date — updated_at is the closest proxy, so posted_date here is
+  # softer evidence than Ashby's. Treat it as "not older than".
+  greenhouse)
+    RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+      "https://boards-api.greenhouse.io/v1/boards/${BOARD}/jobs" 2>/dev/null || echo "")
+
+    if [[ -z "$RESPONSE" ]] || ! jq -e '.jobs' <<<"$RESPONSE" >/dev/null 2>&1; then
+      fail greenhouse "$BOARD" "board not found or API unreachable"
+    fi
+
+    JOBS=$(jq -c '[.jobs[] | {
+      title:       .title,
+      location:    (.location.name // ""),
+      posted_date: ((.updated_at // "") | if . == "" then "unknown" else .[0:10] end),
+      url:         .absolute_url,
+      apply_url:   .absolute_url,
+      remote:      null,
+      listed:      true,
+      department:  ""
+    }]' <<<"$RESPONSE")
+    emit greenhouse "$BOARD" "$JOBS"
+    ;;
+
+  # ── Lever ──────────────────────────────────────────────────────────────────
+  # https://api.lever.co/v0/postings/{company}?mode=json
+  # createdAt is Unix milliseconds.
+  lever)
+    RESPONSE=$(curl -sf --max-time "$TIMEOUT" -A "$UA" \
+      "https://api.lever.co/v0/postings/${BOARD}?mode=json" 2>/dev/null || echo "")
+
+    if [[ -z "$RESPONSE" ]] || ! jq -e 'type == "array"' <<<"$RESPONSE" >/dev/null 2>&1; then
+      fail lever "$BOARD" "board not found or API unreachable"
+    fi
+
+    JOBS=$(jq -c '[.[] | {
+      title:       .text,
+      location:    (.categories.location // ""),
+      posted_date: ((.createdAt // 0) | if . == 0 then "unknown"
+                    else (. / 1000 | strftime("%Y-%m-%d")) end),
+      url:         .hostedUrl,
+      apply_url:   (.applyUrl // .hostedUrl),
+      remote:      null,
+      listed:      true,
+      department:  (.categories.team // "")
+    }]' <<<"$RESPONSE")
+    emit lever "$BOARD" "$JOBS"
+    ;;
+
+  # ── Google ─────────────────────────────────────────────────────────────────
+  # No public API: /api/v3/search/ and careers.google.com/api/v3/ both 404, and the
+  # results page is a client-rendered JS app whose raw HTML carries no listings.
+  # Jina Reader executes the page and returns the rendered result, from which the
+  # posting links can be harvested. Google publishes NO posted date anywhere, so
+  # posted_date is always "unknown" — sort_by=date ordering is the freshness proxy
+  # and job order in `jobs` is preserved (most recent first).
+  #
+  #   fetch-board.sh google "machine learning" "Berlin Germany"
+  google)
+    [[ -z "$JINA_KEY" ]] && fail google "$BOARD" "JINA_API_KEY required for google mode"
+
+    urlencode() { jq -rn --arg v "$1" '$v|@uri'; }
+    Q=$(urlencode "$BOARD")
+    TARGET="https://www.google.com/about/careers/applications/jobs/results/?q=${Q}&sort_by=date"
+    if [[ -n "$EXTRA" ]]; then
+      TARGET="${TARGET}&location=$(urlencode "$EXTRA")"
+    fi
+
+    RENDERED=$(curl -sf --max-time 60 \
+      -H "Authorization: Bearer ${JINA_KEY}" \
+      -H "X-Return-Format: markdown" \
+      "https://r.jina.ai/${TARGET}" 2>/dev/null || echo "")
+
+    [[ -z "$RENDERED" ]] && fail google "$BOARD" "Jina Reader returned nothing"
+
+    # Links look like: .../jobs/results/{numeric-id}-{slug-words}
+    SLUGS=$(grep -oE 'jobs/results/[0-9]+-[a-z0-9-]+' <<<"$RENDERED" | sed 's|jobs/results/||' | awk '!seen[$0]++')
+
+    [[ -z "$SLUGS" ]] && fail google "$BOARD" "no postings matched (or page layout changed)"
+
+    JOBS=$(while IFS= read -r slug; do
+      [[ -z "$slug" ]] && continue
+      # Title = slug with the leading numeric id stripped, dashes to spaces
+      title=$(sed -E 's/^[0-9]+-//; s/-/ /g' <<<"$slug")
+      jq -n --arg title "$title" \
+            --arg url "https://www.google.com/about/careers/applications/jobs/results/${slug}" \
+            --arg loc "${EXTRA:-}" \
+        '{title: $title, location: $loc, posted_date: "unknown",
+          url: $url, apply_url: $url, remote: null, listed: true, department: ""}'
+    done <<<"$SLUGS" | jq -sc '.')
+
+    emit google "$BOARD" "$JOBS"
+    ;;
+
+  *)
+    echo "{\"error\": \"unknown ats '$ATS' — use ashby|greenhouse|lever|google\"}" >&2
+    exit 1
+    ;;
+esac

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -25,7 +25,9 @@
 #   4. Jina Reader (r.jina.ai) — clean markdown for all other URLs
 #   5. WebFetch via curl — plain HTML fallback
 #
-# Requires: curl, jq, grep, sed. Optional: JINA_API_KEY (for Jina Reader).
+# Requires: curl, jq, grep, sed, and perl (used to convert Ashby descriptionHtml to
+# text). Optional: JINA_API_KEY (for Jina Reader).
+# Bash 3.2 compatible — batch mode avoids `wait -n` for macOS's default /bin/bash.
 
 set -euo pipefail
 
@@ -49,15 +51,23 @@ if [[ $# -gt 1 ]]; then
   BATCH_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fetch-job-batch.XXXXXX")
   trap 'rm -rf "$BATCH_DIR"' EXIT
 
+  # Throttle by waiting on the OLDEST pid once $JOBS are in flight. `wait -n`
+  # would be the obvious choice but does not exist in Bash 3.2 — the default
+  # /bin/bash on macOS — where it fails silently and lets the batch fan out
+  # unbounded. This form works on 3.2 and up.
   idx=0
+  PIDS=()
   for u in "$@"; do
     idx=$((idx + 1))
-    # Throttle: wait whenever the number of running children reaches $JOBS
-    while [[ $(jobs -rp | wc -l) -ge $JOBS ]]; do wait -n 2>/dev/null || break; done
     printf -v padded '%04d' "$idx"
     ( bash "$SELF" "$u" > "$BATCH_DIR/$padded.json" 2>/dev/null \
       || jq -n --arg url "$u" '{url:$url,posted_date:"unknown",status:"unknown",content:"",questions:[]}' \
          > "$BATCH_DIR/$padded.json" ) &
+    PIDS+=($!)
+    if [[ ${#PIDS[@]} -ge $JOBS ]]; then
+      wait "${PIDS[0]}" 2>/dev/null || true
+      PIDS=("${PIDS[@]:1}")
+    fi
   done
   wait
 

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -2,7 +2,9 @@
 # fetch-job.sh — Fetch a job posting and extract metadata (URL, content, posted_date, status)
 #
 # Usage:
-#   ./scripts/fetch-job.sh <job-url>
+#   ./scripts/fetch-job.sh <job-url>                  # one posting  → JSON object
+#   ./scripts/fetch-job.sh <url> <url> <url> ...      # many         → JSON array
+#   ./scripts/fetch-job.sh --jobs 8 <url> ...         # set parallelism (default 6)
 #
 # Output: JSON to stdout
 #   { "url": "...", "posted_date": "YYYY-MM-DD|unknown", "status": "open|closed|unknown",
@@ -11,20 +13,59 @@
 #
 # "questions" is the application form's fields when the ATS exposes them
 #
+# Passing several URLs fetches them CONCURRENTLY and emits a JSON array in the same
+# order as the arguments. Scoring a shortlist is the normal case, so prefer one batch
+# call over a shell loop: the loop is serial and pays every network round-trip end to
+# end, while a batch of 15 postings completes in roughly the time of the slowest one.
+#
 # Fetch chain:
 #   1. Greenhouse public API (if URL matches greenhouse.io pattern) — best for dates
-#   2. Jina Reader (r.jina.ai) — clean markdown for all other URLs
-#   3. WebFetch via curl — plain HTML fallback
+#   2. Lever public API
+#   3. Ashby single-posting GraphQL (one posting, ~12KB — never the whole board)
+#   4. Jina Reader (r.jina.ai) — clean markdown for all other URLs
+#   5. WebFetch via curl — plain HTML fallback
 #
-# Requires: curl, jq, JINA_API_KEY env var (for Jina Reader)
+# Requires: curl, jq, grep, sed. Optional: JINA_API_KEY (for Jina Reader).
 
 set -euo pipefail
 
-URL="${1:-}"
-if [[ -z "$URL" ]]; then
-  echo '{"error": "Usage: fetch-job.sh <job-url>"}' >&2
+JOBS=6
+if [[ "${1:-}" == "--jobs" ]]; then
+  JOBS="${2:-6}"
+  shift 2
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo '{"error": "Usage: fetch-job.sh [--jobs N] <job-url> [<job-url> ...]"}' >&2
   exit 1
 fi
+
+# ── batch mode: re-enter this script once per URL, bounded concurrency ────────
+# Each child writes to its own temp file so partial writes can't interleave on
+# stdout; results are then concatenated in argument order.
+
+if [[ $# -gt 1 ]]; then
+  SELF="${BASH_SOURCE[0]}"
+  BATCH_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fetch-job-batch.XXXXXX")
+  trap 'rm -rf "$BATCH_DIR"' EXIT
+
+  idx=0
+  for u in "$@"; do
+    idx=$((idx + 1))
+    # Throttle: wait whenever the number of running children reaches $JOBS
+    while [[ $(jobs -rp | wc -l) -ge $JOBS ]]; do wait -n 2>/dev/null || break; done
+    printf -v padded '%04d' "$idx"
+    ( bash "$SELF" "$u" > "$BATCH_DIR/$padded.json" 2>/dev/null \
+      || jq -n --arg url "$u" '{url:$url,posted_date:"unknown",status:"unknown",content:"",questions:[]}' \
+         > "$BATCH_DIR/$padded.json" ) &
+  done
+  wait
+
+  jq -s '.' "$BATCH_DIR"/*.json
+  exit 0
+fi
+
+URL="$1"
 
 JINA_KEY="${JINA_API_KEY:-}"
 TIMEOUT=20
@@ -121,43 +162,68 @@ if echo "$URL" | grep -qE 'jobs\.lever\.co/([^/]+)/([a-f0-9-]+)'; then
   fi
 fi
 
-# ── Ashby public posting API ──────────────────────────────────────────────────
+# ── Ashby single-posting API ──────────────────────────────────────────────────
 # URL pattern: https://jobs.ashbyhq.com/{board}/{uuid}[/application]
-# The job-board endpoint returns every posting for the board in one unauthenticated
-# call, including publishedAt (a true publish timestamp, unlike Greenhouse's
-# updated_at) and isListed — which is how a delisted-but-still-reachable posting is
-# detected. Preferred over Jina for any Ashby URL.
+#
+# Resolve ONE posting with the public non-user-graphql ApiJobPosting query. The
+# obvious alternative — GET posting-api/job-board/{board} and filter client-side —
+# downloads the entire board to answer a question about a single job: OpenAI's board
+# is 12.5 MB, so scoring a 15-role shortlist that way would pull ~190 MB and risk
+# timeouts. The GraphQL query returns ~12 KB regardless of board size.
+#
+# publishedDate is already YYYY-MM-DD (a true publish date, unlike Greenhouse's
+# updated_at) and isListed detects a delisted-but-still-reachable posting.
+# Board-wide listing still belongs in fetch-board.sh — that's when you want the board.
 
 if echo "$URL" | grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+'; then
-  BOARD=$(echo "$URL" | sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|')
-  JOB_ID=$(echo "$URL" | sed -E 's|.*jobs\.ashbyhq\.com/[^/]+/([A-Za-z0-9-]+).*|\1|')
+  BASE="${URL%%\?*}"; BASE="${BASE%/}"; BASE="${BASE%/application}"
+  BOARD=$(echo "$BASE" | sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|')
+  JOB_ID=$(echo "$BASE" | sed -E 's|.*/([A-Za-z0-9-]+)$|\1|')
 
-  API_URL="https://api.ashbyhq.com/posting-api/job-board/${BOARD}?includeCompensation=true"
-  RESPONSE=$(curl -sf --max-time "$TIMEOUT" "$API_URL" 2>/dev/null || echo "")
+  GQL=$(jq -n --arg org "$BOARD" --arg jid "$JOB_ID" '{
+    operationName: "ApiJobPosting",
+    variables: {organizationHostedJobsPageName: $org, jobPostingId: $jid},
+    query: "query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) { id title departmentName locationName employmentType publishedDate isListed compensationTierSummary descriptionHtml } }"
+  }')
 
-  if [[ -n "$RESPONSE" ]] && echo "$RESPONSE" | jq -e '.jobs' >/dev/null 2>&1; then
-    POSTING=$(echo "$RESPONSE" | jq -c --arg id "$JOB_ID" '.jobs[] | select(.id == $id)')
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" \
+    -H "Content-Type: application/json" \
+    -H "Origin: https://jobs.ashbyhq.com" \
+    --data-raw "$GQL" \
+    "https://jobs.ashbyhq.com/api/non-user-graphql?op=ApiJobPosting" 2>/dev/null || echo "")
 
-    if [[ -n "$POSTING" ]]; then
-      TITLE=$(echo "$POSTING" | jq -r '.title // ""')
-      LOCATION=$(echo "$POSTING" | jq -r '.location // ""')
-      PUBLISHED=$(echo "$POSTING" | jq -r '.publishedAt // ""')
-      POSTED_DATE="${PUBLISHED:0:10}"
-      [[ -z "$POSTED_DATE" ]] && POSTED_DATE="unknown"
-      # isListed false = pulled from the board but the URL still resolves
-      LISTED=$(echo "$POSTING" | jq -r '.isListed // false')
-      if [[ "$LISTED" == "true" ]]; then STATUS="open"; else STATUS="closed"; fi
-      COMP=$(echo "$POSTING" | jq -r '.compensation.compensationTierSummary // ""')
-      BODY=$(echo "$POSTING" | jq -r '.descriptionPlain // ""')
-      CONTENT="# ${TITLE}
-Location: ${LOCATION}
+  if [[ -n "$RESPONSE" ]] && echo "$RESPONSE" | jq -e '.data.jobPosting.id' >/dev/null 2>&1; then
+    POSTING=$(echo "$RESPONSE" | jq -c '.data.jobPosting')
+    TITLE=$(echo "$POSTING"    | jq -r '.title // ""')
+    LOCATION=$(echo "$POSTING" | jq -r '.locationName // ""')
+    DEPT=$(echo "$POSTING"     | jq -r '.departmentName // ""')
+    PUBLISHED=$(echo "$POSTING" | jq -r '.publishedDate // ""')
+    POSTED_DATE="${PUBLISHED:0:10}"
+    [[ -z "$POSTED_DATE" ]] && POSTED_DATE="unknown"
+    # isListed false = pulled from the board but the URL still resolves
+    LISTED=$(echo "$POSTING" | jq -r '.isListed // false')
+    if [[ "$LISTED" == "true" ]]; then STATUS="open"; else STATUS="closed"; fi
+    COMP=$(echo "$POSTING" | jq -r '.compensationTierSummary // ""')
+    # perl, not sed: BSD sed lacks portable in-replacement newlines, and an
+    # alternation group collides with sed's s||| delimiter.
+    BODY=$(echo "$POSTING" | jq -r '.descriptionHtml // ""' \
+      | perl -0777 -pe '
+          s{<li[^>]*>}{\n- }gis;
+          s{<br[^>]*/?>}{\n}gis;
+          s{</(?:p|div|li|ul|ol|h[1-6])>}{\n}gis;
+          s{<[^>]*>}{}gs;
+          s/&amp;/&/g; s/&lt;/</g; s/&gt;/>/g; s/&quot;/"/g;
+          s/&#x27;/'"'"'/g; s/&#39;/'"'"'/g; s/&nbsp;/ /g;
+          s/\n{3,}/\n\n/g;')
+    CONTENT="# ${TITLE}
+Location: ${LOCATION}${DEPT:+
+Department: ${DEPT}}
 Published: ${PUBLISHED}${COMP:+
 Compensation: ${COMP}}
 
 ${BODY}"
-      emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT"
-      exit 0
-    fi
+    emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT"
+    exit 0
   fi
 fi
 

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -121,6 +121,46 @@ if echo "$URL" | grep -qE 'jobs\.lever\.co/([^/]+)/([a-f0-9-]+)'; then
   fi
 fi
 
+# ── Ashby public posting API ──────────────────────────────────────────────────
+# URL pattern: https://jobs.ashbyhq.com/{board}/{uuid}[/application]
+# The job-board endpoint returns every posting for the board in one unauthenticated
+# call, including publishedAt (a true publish timestamp, unlike Greenhouse's
+# updated_at) and isListed — which is how a delisted-but-still-reachable posting is
+# detected. Preferred over Jina for any Ashby URL.
+
+if echo "$URL" | grep -qE 'jobs\.ashbyhq\.com/[^/]+/[A-Za-z0-9-]+'; then
+  BOARD=$(echo "$URL" | sed -E 's|.*jobs\.ashbyhq\.com/([^/]+)/.*|\1|')
+  JOB_ID=$(echo "$URL" | sed -E 's|.*jobs\.ashbyhq\.com/[^/]+/([A-Za-z0-9-]+).*|\1|')
+
+  API_URL="https://api.ashbyhq.com/posting-api/job-board/${BOARD}?includeCompensation=true"
+  RESPONSE=$(curl -sf --max-time "$TIMEOUT" "$API_URL" 2>/dev/null || echo "")
+
+  if [[ -n "$RESPONSE" ]] && echo "$RESPONSE" | jq -e '.jobs' >/dev/null 2>&1; then
+    POSTING=$(echo "$RESPONSE" | jq -c --arg id "$JOB_ID" '.jobs[] | select(.id == $id)')
+
+    if [[ -n "$POSTING" ]]; then
+      TITLE=$(echo "$POSTING" | jq -r '.title // ""')
+      LOCATION=$(echo "$POSTING" | jq -r '.location // ""')
+      PUBLISHED=$(echo "$POSTING" | jq -r '.publishedAt // ""')
+      POSTED_DATE="${PUBLISHED:0:10}"
+      [[ -z "$POSTED_DATE" ]] && POSTED_DATE="unknown"
+      # isListed false = pulled from the board but the URL still resolves
+      LISTED=$(echo "$POSTING" | jq -r '.isListed // false')
+      if [[ "$LISTED" == "true" ]]; then STATUS="open"; else STATUS="closed"; fi
+      COMP=$(echo "$POSTING" | jq -r '.compensation.compensationTierSummary // ""')
+      BODY=$(echo "$POSTING" | jq -r '.descriptionPlain // ""')
+      CONTENT="# ${TITLE}
+Location: ${LOCATION}
+Published: ${PUBLISHED}${COMP:+
+Compensation: ${COMP}}
+
+${BODY}"
+      emit_json "$URL" "$POSTED_DATE" "$STATUS" "$CONTENT"
+      exit 0
+    fi
+  fi
+fi
+
 # ── Jina Reader ───────────────────────────────────────────────────────────────
 
 if [[ -n "$JINA_KEY" ]]; then

--- a/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
+++ b/.claude/skills/find-kristian-jobs/scripts/fetch-job.sh
@@ -35,6 +35,14 @@ JOBS=6
 if [[ "${1:-}" == "--jobs" ]]; then
   JOBS="${2:-6}"
   shift 2
+  # Validate before use: an unvalidated value reaches an arithmetic comparison
+  # below, where a non-numeric string is treated as a variable name and aborts
+  # the script under `set -u` ("abc: unbound variable"), and 0 would throttle on
+  # every iteration — silently turning the batch back into a serial loop.
+  if ! [[ "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "{\"error\": \"--jobs must be a positive integer, got: $JOBS\"}" >&2
+    exit 1
+  fi
 fi
 
 if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
Adds Google Careers and Elicit as scan sources, and — while probing for how to read them — 9 more company boards that were previously browser-scraped or not covered at all.

## What's new

`scripts/fetch-board.sh <ashby|greenhouse|lever|google> <board>` — lists a whole company job board in one unauthenticated call, returning `{title, location, posted_date, url, apply_url, remote, listed}` per role.

| Source | How it reads | Notes |
|---|---|---|
| **Elicit** | Ashby posting API | True `publishedAt` + `isListed`. Best data quality in the skill. All eng roles are US-timezone-only, though |
| **Google Careers** | Jina Reader on the JS results page | No API exists (both v3 endpoints 404). No posted date published anywhere |
| **OpenAI** | ashby `openai` | 741 roles — replaces a browser scrape |
| **Anthropic** | greenhouse `anthropic` | 407 roles — replaces a browser scrape |
| **Google DeepMind** | greenhouse `deepmind` | 10 roles — Tier 1 company, previously zero coverage |
| Cohere, Notion, Replit, LangChain, Vercel, CZI, Elsevier | ashby/greenhouse | newly covered |

All 11 boards verified returning live data.

## Behaviour changes

- **Freshness overrides per source.** Google publishes no dates, so the blanket "deprioritize unknown dates" rule would have silently killed every Google role — it's now exempted and relies on `sort_by=date` ordering. Ashby dates are trusted strictly (its boards carry zombie postings: Elicit still lists a 2021 role as `isListed: true`). Greenhouse `updated_at` is documented as a "not older than" proxy, not a publish date.
- **Geography pre-filter** runs before fetching a posting: US-timezone-locked remote roles are dropped rather than fetched and scored to ~60%. Dropped companies get reported, not silently skipped.
- **Board API calls are excluded from the browser page budget** — they're one curl each, so there's no reason to ration them.
- Google is searched by keyword, never by bare location: the unfiltered Berlin list is ~13 roles that are almost all Cloud sales; one keyword query cut it to the single relevant hit.

## Files

- `scripts/fetch-board.sh` (new)
- `scripts/fetch-job.sh` — Ashby branch added to the fetch chain
- `references/job-sources.md` (new) — the source registry
- `SKILL.md`, `references/target-companies.md` — wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)