### PR TITLE
fix(generate-application): stop volunteering gaps in cover letters

### DIFF
--- a/.claude/skills/generate-application/SKILL.md
+++ b/.claude/skills/generate-application/SKILL.md
@@ -198,7 +198,7 @@ Tell the user:
 ## Notes
 
 - Always read the full posting before scoring — do not assume from job title alone
-- Be honest about gaps — authenticity over overselling
+- Be honest about gaps in `analysis.md` — authenticity over overselling. But keep gap admissions OUT of the cover letter itself; the letter sells fit, it does not disclaim it (see `references/tone-and-voice.md`)
 - The cover letter body must be exactly 2 paragraphs. The agent enforces this.
 - The package is not complete without `application-questions.md` — either with the form's questions answered, or with an explicit note that the form is behind a login/JS wall and must be checked manually
 - If the job URL redirects or is behind a wall, ask the user to paste the posting text directly

--- a/.claude/skills/generate-application/references/tone-and-voice.md
+++ b/.claude/skills/generate-application/references/tone-and-voice.md
@@ -10,6 +10,7 @@
 - **Avoid AI-slop punctuation.** Do not use em dashes in cover letters. Prefer plain punctuation like commas and periods.
 - **Use a concise close.** End with a brief, professional closing line such as "Sincerely," without filler or long pleasantries.
 - **No buzzword padding.** Cut "passionate", "dynamic", "synergy", "leverage", "thought leader". Every adjective needs a fact behind it.
+- **Never volunteer a gap unprompted.** Gap honesty belongs in `analysis.md` (internal) and in factual screener answers when the form directly asks. The cover letter itself sells fit — do not write sentences like "my experience has been X rather than Y, so I'd be building on that muscle." ML6 rejected a 2026-07-17 application citing the exact gap ("external stakeholder management/client communication") the cover letter volunteered unprompted in paragraph 2. If a real gap exists, either omit it from the letter or reframe it as adjacent proof (nearest evidence you do have), never as a disclaimer.
 
 ## CV Profile Statement Tone
 


### PR DESCRIPTION
## Summary
- ML6 rejected a 2026-07-17 application citing the exact gap ("external stakeholder management/client communication") the cover letter admitted unprompted in paragraph 2.
- Gap honesty now stays confined to `analysis.md` / factual screener answers — the cover letter sells fit, it does not disclaim it.

## Test plan
- [ ] Regenerate an application package and confirm the cover-letter-writer agent no longer inserts self-disclaimer sentences
- [ ] Spot-check `references/tone-and-voice.md` and `SKILL.md` Notes section read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPVNukQD1PhvncHpneVK6a